### PR TITLE
change UNPACK_ERROR logic to support custom error handlers

### DIFF
--- a/protobuf-c-rpc/protobuf-c-data-buffer.c
+++ b/protobuf-c-rpc/protobuf-c-data-buffer.c
@@ -261,7 +261,8 @@ void
 protobuf_c_data_buffer_append_string(ProtobufCDataBuffer  *buffer,
                          const char *string)
 {
-  assert (string != NULL);
+  if (string == NULL)
+     return;
   protobuf_c_data_buffer_append (buffer, string, strlen (string));
 }
 
@@ -339,7 +340,8 @@ protobuf_c_data_buffer_read(ProtobufCDataBuffer    *buffer,
 	}
     }
   buffer->size -= rv;
-  assert (rv == orig_max_length || buffer->size == 0);
+  if (rv != orig_max_length && buffer->size != 0)
+     return 0;
   CHECK_INTEGRITY (buffer);
   return rv;
 }

--- a/protobuf-c/protobuf-c.h
+++ b/protobuf-c/protobuf-c.h
@@ -133,7 +133,6 @@ typedef int protobuf_c_boolean;
 #define PROTOBUF_C_OFFSETOF(struct, member) offsetof(struct, member)
 
 #define PROTOBUF_C_ASSERT(condition) assert(condition)
-#define PROTOBUF_C_ASSERT_NOT_REACHED() assert(0)
 
 typedef struct _ProtobufCBinaryData ProtobufCBinaryData;
 struct _ProtobufCBinaryData


### PR DESCRIPTION
configure.ac: add header check for stdarg.h

protobuf-c/protobuf-c.c: change UNPACK_ERROR logic to support custom
error handlers (fixes #26)

protobuf-c/protobuf-c.h: define new error handling structures and add
them to the ProtobufCAllocator structure
