### PR TITLE
Issue #106 fix possible overflow on 64-bit systems

### DIFF
--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -2246,7 +2246,7 @@ protobuf_c_message_init_generic (const ProtobufCMessageDescriptor *desc,
    choose the number so that we would overflow if we needed
    a slab larger than provided. */
 #define MAX_SCANNED_MEMBER_SLAB                          \
-  (sizeof(void*)*8 - 1                                   \
+  (sizeof(unsigned int)*8 - 1                                   \
    - BOUND_SIZEOF_SCANNED_MEMBER_LOG2                    \
    - FIRST_SCANNED_MEMBER_SLAB_SIZE_LOG2)
 


### PR DESCRIPTION
This patch 'does nothing' on 32-bit bit systems since sizeof(void*)==sizeof(unsigned).
On the 64-bit systems this will equal the value on 32-bit systems preventing an overflow. 
