### PR TITLE
Autoconf portability tweaks.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -162,5 +162,6 @@ dist-hook:
 	rm -vf `find $(top_distdir) -name '*.pb-c.[ch]' -o -name '*.pb.cc' -o -name '*.pb.h'`
 
 install-data-hook:
-	mkdir -p $(DESTDIR)$(includedir)/google
-	ln -sf ../protobuf-c $(DESTDIR)$(includedir)/google/
+	$(MKDIR_P) $(DESTDIR)$(includedir)/google/protobuf-c
+	cd $(DESTDIR)$(includedir)/google/protobuf-c && rm -vf protobuf-c.h
+	cd $(DESTDIR)$(includedir)/google/protobuf-c && $(LN_S) ../../protobuf-c/protobuf-c.h protobuf-c.h

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,8 @@ AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign 1.11 -Wall -Wno-portability silent-rules subdir-objects])
 AC_PROG_CC_STDC
 AC_PROG_CXX
+AC_PROG_LN_S
+AC_PROG_MKDIR_P
 AC_USE_SYSTEM_EXTENSIONS
 AC_SYS_LARGEFILE
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
Use MKDIR_P and LN_S rather than their usual expansions.
