### PR TITLE
fixed gcc warnings 'integer constant is so large that it is unsigned'

### DIFF
--- a/protoc-c/c_primitive_field.cc
+++ b/protoc-c/c_primitive_field.cc
@@ -130,11 +130,11 @@ string PrimitiveFieldGenerator::GetDefaultValue() const
     case FieldDescriptor::CPPTYPE_INT32:
       return SimpleItoa(descriptor_->default_value_int32());
     case FieldDescriptor::CPPTYPE_INT64:
-      return SimpleItoa(descriptor_->default_value_int64());
+      return SimpleItoa(descriptor_->default_value_int64()) + "ll";
     case FieldDescriptor::CPPTYPE_UINT32:
-      return SimpleItoa(descriptor_->default_value_uint32());
+      return SimpleItoa(descriptor_->default_value_uint32()) + "u";
     case FieldDescriptor::CPPTYPE_UINT64:
-      return SimpleItoa(descriptor_->default_value_uint64());
+      return SimpleItoa(descriptor_->default_value_uint64()) + "ull";
     case FieldDescriptor::CPPTYPE_FLOAT:
       return SimpleFtoa(descriptor_->default_value_float());
     case FieldDescriptor::CPPTYPE_DOUBLE:


### PR DESCRIPTION
An easy one, here is a .proto file to reproduce:

message test {
        optional uint64 test = 1 [default=18446744073709551615];
}

Without the fix compiler complains like this:

$ gcc -c test.pb-c.c 
test.pb-c.c: In function ‘test__init’:
test.pb-c.c:13:28: warning: integer constant is so large that it is unsigned [enabled by default]
test.pb-c.c:13:3: warning: this decimal constant is unsigned only in ISO C90 [enabled by default]
test.pb-c.c: At top level:
test.pb-c.c:53:51: warning: integer constant is so large that it is unsigned [enabled by default]
test.pb-c.c:53:1: warning: this decimal constant is unsigned only in ISO C90 [enabled by default]
