### PR TITLE
protobuf-c.c: Fix repeated field concatenation order in merge_messages

### DIFF
--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -1933,12 +1933,12 @@ merge_messages(ProtobufCMessage *earlier_msg,
 					if (!new_field)
 						return FALSE;
 
-					memcpy(new_field, *p_latter,
-					       *n_latter * el_size);
-					memcpy(new_field +
-					       *n_latter * el_size,
-					       *p_earlier,
+					memcpy(new_field, *p_earlier,
 					       *n_earlier * el_size);
+					memcpy(new_field +
+					       *n_earlier * el_size,
+					       *p_latter,
+					       *n_latter * el_size);
 
 					do_free(allocator, *p_latter);
 					do_free(allocator, *p_earlier);

--- a/t/generated-code2/test-generated-code2.c
+++ b/t/generated-code2/test-generated-code2.c
@@ -1469,8 +1469,8 @@ test_field_merge (void)
    msg2.test_message = &sub2;
    sub2.has_val2 = 1;
    sub2.val2 = 666;
-   int32_t arr2[] = {2, 3};
-   sub2.n_rep = 2;
+   int32_t arr2[] = {2, 3, 4};
+   sub2.n_rep = 3;
    sub2.rep = arr2;
    sub2.sub1 = &subsub2;
    subsub2.has_val1 = 1;
@@ -1496,8 +1496,8 @@ test_field_merge (void)
    assert (merged->test_message->has_val1 && merged->test_message->val1 == sub1.val1);
    assert (merged->test_message->has_val2 && merged->test_message->val2 == sub2.val2);
    /* Repeated fields should get concatenated */
-   int32_t merged_arr[] = {2, 3, 0, 1};
-   assert (merged->test_message->n_rep == 4 &&
+   int32_t merged_arr[] = {0, 1, 2, 3, 4};
+   assert (merged->test_message->n_rep == 5 &&
            memcmp(merged->test_message->rep, merged_arr, sizeof(merged_arr)) == 0);
 
    assert (merged->test_message->sub1->val1 == subsub2.val1);


### PR DESCRIPTION
Concatenate earlier field to latter, not vice versa.

Fix test cases to reflect the change.

Fixes #147 
