### PR TITLE
Add cmake build system and VS2013 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ t/generated-code2/cxx-generate-packed-data
 t/generated-code2/test-full-cxx-output.inc
 t/generated-code2/test-generated-code2
 t/version/version
+build-cmake/
 *.pb-c.c
 *.pb-c.h
 *.pb.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,54 @@
+SET(PACKAGE protobuf-c)
+SET(PACKAGE_NAME protobuf-c)
+SET(PACKAGE_VERSION 1.0.0)
+
+
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8 FATAL_ERROR)
+
+PROJECT(protobuf-c)
+
+INCLUDE(TestBigEndian)
+TEST_BIG_ENDIAN(WORDS_BIGENDIAN)
+set(PACKAGE_STRING "${PACKAGE_NAME} ${PACKAGE_VERSION}")
+add_definitions(-DPACKAGE_VERSION="${PACKAGE_VERSION}")
+add_definitions(-DPACKAGE_STRING="${PACKAGE_STRING}")
+add_definitions(-DWORDS_BIGENDIAN=${WORDS_BIGENDIAN})
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+  # using Visual Studio C++
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4267 /wd4244")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267 /wd4244")
+endif()
+
+
+include_directories(${CMAKE_BINARY_DIR})
+
+SET (PC_SOURCES 
+        protobuf-c/protobuf-c.c 
+        protobuf-c/protobuf-c.h)
+
+add_library(protobuf-c ${PC_SOURCES})
+
+include_directories(${CMAKE_SOURCE_DIR})
+include_directories(${CMAKE_SOURCE_DIR}/protobuf-c)
+
+
+find_package(Protobuf REQUIRED)
+include_directories(${PROTOBUF_INCLUDE_DIR})
+
+file(GLOB PROTOC_SRC protoc-c/*.h protoc-c/*.cc )
+add_executable(protoc-c ${PROTOC_SRC})
+
+target_link_libraries(protoc-c ${PROTOBUF_PROTOC_LIBRARY} ${PROTOBUF_LIBRARY})
+
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+  enable_testing()
+  add_subdirectory(t)
+endif()
+
+
+
+install(TARGETS protoc-c protobuf-c RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
+INSTALL(FILES protobuf-c/protobuf-c.h DESTINATION include)
+
+INCLUDE(CPack)

--- a/build-cmake/build.bat
+++ b/build-cmake/build.bat
@@ -1,0 +1,4 @@
+call "%VS120COMNTOOLS%\..\..\VC\vcvarsall.bat" x86_amd64
+cmake .. -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=x:\libs18
+nmake install
+                                                                                                                 

--- a/build-cmake/build_debug.bat
+++ b/build-cmake/build_debug.bat
@@ -1,0 +1,4 @@
+call "%VS120COMNTOOLS%\..\..\VC\vcvarsall.bat" x86_amd64
+cmake .. -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=x:\libs18d -DCMAKE_BUILD_TYPE=Debug
+nmake install
+ctest -VV

--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -50,6 +50,11 @@
 
 #include "protobuf-c.h"
 
+#ifdef _MSC_VER
+// MSVC does not fully support C99, inline should be replaced
+#define inline _inline
+#endif
+
 #define TRUE				1
 #define FALSE				0
 
@@ -2399,7 +2404,7 @@ parse_packed_repeated_member(ScannedMember *scanned_member,
 	const ProtobufCFieldDescriptor *field = scanned_member->field;
 	size_t *p_n = STRUCT_MEMBER_PTR(size_t, message, field->quantifier_offset);
 	size_t siz = sizeof_elt_in_repeated_array(field->type);
-	void *array = *(void **) member + siz * (*p_n);
+	void *array = ((char*)*(void **) member) + siz * (*p_n);
 	const uint8_t *at = scanned_member->data + scanned_member->length_prefix_len;
 	size_t rem = scanned_member->len - scanned_member->length_prefix_len;
 	size_t count = 0;

--- a/protobuf-c/protobuf-c.h
+++ b/protobuf-c/protobuf-c.h
@@ -208,9 +208,11 @@ PROTOBUF_C__BEGIN_DECLS
 #if !defined(PROTOBUF_C__NO_DEPRECATED)
 # if (__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1)
 #  define PROTOBUF_C__DEPRECATED __attribute__((__deprecated__))
+# else
+#  define PROTOBUF_C__DEPRECATED
 # endif
 #else
-# define PROTOBUF_C__DEPRECATED
+#define PROTOBUF_C__DEPRECATED
 #endif
 
 #ifndef PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -1,0 +1,41 @@
+ADD_CUSTOM_COMMAND(OUTPUT test.pb-c.c test.pb-c.h
+                   COMMAND protoc-c -I${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/test.proto --c_out=${CMAKE_BINARY_DIR}
+                   DEPENDS protoc-c
+                   )
+
+
+ADD_EXECUTABLE(test-generated-code generated-code/test-generated-code.c test.pb-c.c test.pb-c.h )
+
+TARGET_LINK_LIBRARIES(test-generated-code protobuf-c)
+
+
+INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR})
+
+PROTOBUF_GENERATE_CPP(CPPS HS ${CMAKE_SOURCE_DIR}/t/test-full.proto)
+
+ADD_CUSTOM_COMMAND(OUTPUT test-full.pb-c.c test-full.pb-c.h
+                   COMMAND protoc-c -I${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/t/test-full.proto --c_out=${CMAKE_BINARY_DIR}
+                   DEPENDS protoc-c
+                   )
+
+ADD_EXECUTABLE(cxx-generate-packed-data generated-code2/cxx-generate-packed-data.cc test-full.pb.h  test-full.pb.cc)
+TARGET_LINK_LIBRARIES(cxx-generate-packed-data ${PROTOBUF_LIBRARY})
+
+FILE(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/t/generated-code2)
+ADD_CUSTOM_COMMAND(OUTPUT t/generated-code2/test-full-cxx-output.inc
+                   COMMAND ${CMAKE_BINARY_DIR}/t/cxx-generate-packed-data ">generated-code2/test-full-cxx-output.inc"
+                   DEPENDS cxx-generate-packed-data
+                   )
+
+ADD_EXECUTABLE(test-generated-code2 generated-code2/test-generated-code2.c t/generated-code2/test-full-cxx-output.inc test-full.pb-c.h test-full.pb-c.c)
+TARGET_LINK_LIBRARIES(test-generated-code2  protobuf-c)
+
+ADD_EXECUTABLE(test-version version/version.c)
+TARGET_LINK_LIBRARIES(test-version protobuf-c)
+
+
+INCLUDE(Dart)
+SET(DART_TESTING_TIMEOUT 5)
+ADD_TEST(test-generated-code test-generated-code)
+ADD_TEST(test-generated-code2 test-generated-code2)
+ADD_TEST(test-version test-version)


### PR DESCRIPTION
I needed to build project based on protobuf-c (osm2pgsql) with Microsoft Compiler under Windows. Earlier the library already had MSVC support, so patching was minimal (two changes in protobuf-c.c ).

However, autotools build system is very hard to use on Windows (only with cygwin/mingw with many incompatibilities). So the CMake build scripts were created. The scripts are also usable on Unix systems (tested on FreeBSD 10). To build user needs to run something like

```
cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX=c:\libs
nmake install
```

(protobuf installed in `c:\libs`  is needed). Tested on free Visual Studio Express 2013.

 I tried to include testing support (`ctest` will run all the tests, alternative to `make check`) but did not bother to use valgrind or gcov (I doubt cmake will replace autotools completely for now). 
