### PR TITLE
fix parallel build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -141,7 +141,7 @@ noinst_PROGRAMS += \
 t_generated_code2_cxx_generate_packed_data_SOURCES = \
 	t/generated-code2/cxx-generate-packed-data.cc \
 	t/test-full.pb.cc
-t/generated-code2/cxx-generate-packed-data.$(OBJEXT): t/test-full.pb.h
+$(t_generated_code2_cxx_generate_packed_data_OBJECTS): t/test-full.pb.h
 t_generated_code2_cxx_generate_packed_data_CXXFLAGS = \
 	$(AM_CXXFLAGS) \
 	$(protobuf_CFLAGS)


### PR DESCRIPTION
The object file name is not what expected when building non-recursive.
Rather that expect autoamek to generate a specific filename, we simply
make the generated header a dependency of all objects for
cxx-generate-packed-data.

This fixes issue #156.
