### PR TITLE
protoc-c: Print leading comments for enum, message, and field definitions

### DIFF
--- a/protoc-c/c_enum.cc
+++ b/protoc-c/c_enum.cc
@@ -86,6 +86,10 @@ void EnumGenerator::GenerateDefinition(io::Printer* printer) {
   vars["shortname"] = descriptor_->name();
   vars["uc_name"] = FullNameToUpper(descriptor_->full_name());
 
+  SourceLocation sourceLoc;
+  descriptor_->GetSourceLocation(&sourceLoc);
+  PrintComment (printer, sourceLoc.leading_comments);
+
   printer->Print(vars, "typedef enum _$classname$ {\n");
   printer->Indent();
 
@@ -101,6 +105,11 @@ void EnumGenerator::GenerateDefinition(io::Printer* printer) {
     if (i + 1 == descriptor_->value_count())
       vars["opt_comma"] = "";
 
+    SourceLocation valSourceLoc;
+    descriptor_->value(i)->GetSourceLocation(&valSourceLoc);
+
+    PrintComment (printer, valSourceLoc.leading_comments);
+    PrintComment (printer, valSourceLoc.trailing_comments);
     printer->Print(vars, "$prefix$$name$ = $number$$opt_comma$\n");
 
     if (descriptor_->value(i)->number() < min_value->number()) {

--- a/protoc-c/c_helpers.cc
+++ b/protoc-c/c_helpers.cc
@@ -210,6 +210,28 @@ string FullNameToC(const string &full_name) {
   return rv;
 }
 
+void PrintComment (io::Printer* printer, string comment)
+{
+   if (!comment.empty())
+   {
+      vector<string> comment_lines;
+      SplitStringUsing (comment, "\r\n", &comment_lines);
+      printer->Print ("/*\n");
+      for (int i = 0; i < comment_lines.size(); i++)
+      {
+         if (!comment_lines[i].empty())
+         {
+            /* Make sure we don't inadvertently close the comment block */
+            if (comment_lines[i][0] == '/')
+               comment_lines[i] = ' ' + comment_lines[i];
+
+            printer->Print (" *$line$\n", "line", comment_lines[i]);
+         }
+      }
+      printer->Print (" */\n");
+   }
+}
+
 string ConvertToSpaces(const string &input) {
   return string(input.size(), ' ');
 }

--- a/protoc-c/c_helpers.h
+++ b/protoc-c/c_helpers.h
@@ -138,6 +138,9 @@ string FullNameToUpper(const string &full_name);
 // full_name() to c-typename (with underscores for packages, otherwise camel case)
 string FullNameToC(const string &class_name);
 
+// Splits, indents, formats, and prints comment lines
+void PrintComment (io::Printer* printer, string comment);
+
 // make a string of spaces as long as input
 string ConvertToSpaces(const string &input);
 

--- a/protoc-c/c_message.cc
+++ b/protoc-c/c_message.cc
@@ -166,6 +166,10 @@ GenerateStructDefinition(io::Printer* printer) {
     printer->Print(vars, "} $foneofname$Case;\n\n");
   }
 
+  SourceLocation msgSourceLoc;
+  descriptor_->GetSourceLocation(&msgSourceLoc);
+  PrintComment (printer, msgSourceLoc.leading_comments);
+
   printer->Print(vars,
     "struct $dllexport$ _$classname$\n"
     "{\n"
@@ -176,6 +180,11 @@ GenerateStructDefinition(io::Printer* printer) {
   for (int i = 0; i < descriptor_->field_count(); i++) {
     const FieldDescriptor *field = descriptor_->field(i);
     if (field->containing_oneof() == NULL) {
+      SourceLocation fieldSourceLoc;
+      field->GetSourceLocation(&fieldSourceLoc);
+
+      PrintComment (printer, fieldSourceLoc.leading_comments);
+      PrintComment (printer, fieldSourceLoc.trailing_comments);
       field_generators_.get(field).GenerateStructMembers(printer);
     }
   }
@@ -192,6 +201,11 @@ GenerateStructDefinition(io::Printer* printer) {
     printer->Indent();
     for (int j = 0; j < oneof->field_count(); j++) {
       const FieldDescriptor *field = oneof->field(j);
+      SourceLocation fieldSourceLoc;
+      field->GetSourceLocation(&fieldSourceLoc);
+
+      PrintComment (printer, fieldSourceLoc.leading_comments);
+      PrintComment (printer, fieldSourceLoc.trailing_comments);
       field_generators_.get(field).GenerateStructMembers(printer);
     }
     printer->Outdent();


### PR DESCRIPTION
This is useful if .proto files contain a lot of explanations and then the source code is referenced in an IDE or a debugger. This change attempts to move leading comments from .proto to enum, struct, and field definitions in the generated .pb-c.h file.
