### PR TITLE
protoc-c/c_helpers.cc: Enhance comment string parsing

### DIFF
--- a/protoc-c/c_helpers.cc
+++ b/protoc-c/c_helpers.cc
@@ -225,6 +225,14 @@ void PrintComment (io::Printer* printer, string comment)
             if (comment_lines[i][0] == '/')
                comment_lines[i] = ' ' + comment_lines[i];
 
+            /* Or cause other compiler issues. */
+            size_t delim_i;
+            while ((delim_i = comment_lines[i].find("/*")) != string::npos)
+               comment_lines[i][delim_i] = ' ';
+
+            while ((delim_i = comment_lines[i].find("*/")) != string::npos)
+               comment_lines[i][delim_i + 1] = ' ';
+
             printer->Print (" *$line$\n", "line", comment_lines[i]);
          }
       }


### PR DESCRIPTION
Certain protobuf comments could generate invalid C comments
and inadvertently close the comment block. This commit removes '/'
signs in such comments