### PR TITLE
Lite runtime

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -131,7 +131,8 @@ t_generated_code_test_generated_code_LDADD = \
 
 t_generated_code2_test_generated_code2_SOURCES = \
 	t/generated-code2/test-generated-code2.c \
-	t/test-full.pb-c.c
+	t/test-full.pb-c.c \
+	t/test-optimized.pb-c.c
 t_generated_code2_test_generated_code2_LDADD = \
 	protobuf-c/libprotobuf-c.la
 
@@ -151,6 +152,9 @@ t_generated_code2_cxx_generate_packed_data_LDADD = \
 t/test.pb-c.c t/test.pb-c.h: $(top_builddir)/protoc-c/protoc-c$(EXEEXT) $(top_srcdir)/t/test.proto
 	$(AM_V_GEN)$(top_builddir)/protoc-c/protoc-c$(EXEEXT) -I$(top_srcdir) --c_out=$(top_builddir) $(top_srcdir)/t/test.proto
 
+t/test-optimized.pb-c.c t/test-optimized.pb-c.h: $(top_builddir)/protoc-c/protoc-c$(EXEEXT) $(top_srcdir)/t/test-optimized.proto
+	$(AM_V_GEN)$(top_builddir)/protoc-c/protoc-c$(EXEEXT) -I$(top_srcdir) --c_out=$(top_builddir) $(top_srcdir)/t/test-optimized.proto
+
 t/test-full.pb-c.c t/test-full.pb-c.h: $(top_builddir)/protoc-c/protoc-c$(EXEEXT) $(top_srcdir)/t/test-full.proto
 	$(AM_V_GEN)$(top_builddir)/protoc-c/protoc-c$(EXEEXT) -I$(top_srcdir) --c_out=$(top_builddir) $(top_srcdir)/t/test-full.proto
 
@@ -163,6 +167,7 @@ t/generated-code2/test-full-cxx-output.inc: t/generated-code2/cxx-generate-packe
 BUILT_SOURCES += \
 	t/test.pb-c.c t/test.pb-c.h \
 	t/test-full.pb-c.c t/test-full.pb-c.h \
+	t/test-optimized.pb-c.c t/test-optimized.pb-c.h \
 	t/test-full.pb.cc t/test-full.pb.h \
 	t/generated-code2/test-full-cxx-output.inc
 
@@ -176,6 +181,7 @@ endif # BUILD_COMPILER
 EXTRA_DIST += \
 	t/test.proto \
 	t/test-full.proto \
+	t/test-optimized.proto \
 	t/generated-code2/common-test-arrays.h
 
 #

--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -3381,6 +3381,9 @@ const ProtobufCEnumValue *
 protobuf_c_enum_descriptor_get_value_by_name(const ProtobufCEnumDescriptor *desc,
 					     const char *name)
 {
+	if (desc == NULL || desc->values_by_name == NULL)
+		return NULL;
+
 	unsigned start = 0;
 	unsigned count = desc->n_value_names;
 
@@ -3416,6 +3419,9 @@ const ProtobufCFieldDescriptor *
 protobuf_c_message_descriptor_get_field_by_name(const ProtobufCMessageDescriptor *desc,
 						const char *name)
 {
+	if (desc == NULL || desc->fields_sorted_by_name == NULL)
+		return NULL;
+
 	unsigned start = 0;
 	unsigned count = desc->n_fields;
 	const ProtobufCFieldDescriptor *field;
@@ -3455,6 +3461,9 @@ const ProtobufCMethodDescriptor *
 protobuf_c_service_descriptor_get_method_by_name(const ProtobufCServiceDescriptor *desc,
 						 const char *name)
 {
+	if (desc == NULL || desc->method_indices_by_name == NULL)
+		return NULL;
+
 	unsigned start = 0;
 	unsigned count = desc->n_methods;
 

--- a/protobuf-c/protobuf-c.h
+++ b/protobuf-c/protobuf-c.h
@@ -806,7 +806,7 @@ protobuf_c_version_number(void);
  * \return
  *      A `ProtobufCEnumValue` object.
  * \retval NULL
- *      If not found.
+ *      If not found or if the optimize_for = LITE_RUNTIME option was set.
  */
 PROTOBUF_C__API
 const ProtobufCEnumValue *
@@ -846,7 +846,7 @@ protobuf_c_enum_descriptor_get_value(
  * \return
  *      A `ProtobufCFieldDescriptor` object.
  * \retval NULL
- *      If not found.
+ *      If not found or if the optimize_for = LITE_RUNTIME option was set.
  */
 PROTOBUF_C__API
 const ProtobufCFieldDescriptor *
@@ -1020,7 +1020,7 @@ protobuf_c_service_destroy(ProtobufCService *service);
  * \return
  *      A `ProtobufCMethodDescriptor` object.
  * \retval NULL
- *      If not found.
+ *      If not found or if the optimize_for = LITE_RUNTIME option was set.
  */
 PROTOBUF_C__API
 const ProtobufCMethodDescriptor *

--- a/protobuf-c/protobuf-c.h
+++ b/protobuf-c/protobuf-c.h
@@ -806,7 +806,7 @@ protobuf_c_version_number(void);
  * \return
  *      A `ProtobufCEnumValue` object.
  * \retval NULL
- *      If not found or if the optimize_for = LITE_RUNTIME option was set.
+ *      If not found or if the optimize_for = CODE_SIZE option was set.
  */
 PROTOBUF_C__API
 const ProtobufCEnumValue *
@@ -846,7 +846,7 @@ protobuf_c_enum_descriptor_get_value(
  * \return
  *      A `ProtobufCFieldDescriptor` object.
  * \retval NULL
- *      If not found or if the optimize_for = LITE_RUNTIME option was set.
+ *      If not found or if the optimize_for = CODE_SIZE option was set.
  */
 PROTOBUF_C__API
 const ProtobufCFieldDescriptor *
@@ -1020,7 +1020,7 @@ protobuf_c_service_destroy(ProtobufCService *service);
  * \return
  *      A `ProtobufCMethodDescriptor` object.
  * \retval NULL
- *      If not found or if the optimize_for = LITE_RUNTIME option was set.
+ *      If not found or if the optimize_for = CODE_SIZE option was set.
  */
 PROTOBUF_C__API
 const ProtobufCMethodDescriptor *

--- a/protoc-c/c_enum.cc
+++ b/protoc-c/c_enum.cc
@@ -150,11 +150,17 @@ void EnumGenerator::GenerateValueInitializer(io::Printer *printer, int index)
 {
   const EnumValueDescriptor *vd = descriptor_->value(index);
   map<string, string> vars;
+  bool lite_runtime = descriptor_->file()->options().has_optimize_for() &&
+    descriptor_->file()->options().optimize_for() ==
+    FileOptions_OptimizeMode_LITE_RUNTIME;
   vars["enum_value_name"] = vd->name();
   vars["c_enum_value_name"] = FullNameToUpper(descriptor_->full_name()) + "__" + vd->name();
   vars["value"] = SimpleItoa(vd->number());
-  printer->Print(vars,
-   "  { \"$enum_value_name$\", \"$c_enum_value_name$\", $value$ },\n");
+  if (lite_runtime)
+    printer->Print(vars, "  { NULL, NULL, $value$ }, /* LITE_RUNTIME */\n");
+  else
+    printer->Print(vars,
+        "  { \"$enum_value_name$\", \"$c_enum_value_name$\", $value$ },\n");
 }
 
 static int compare_value_indices_by_value_then_index(const void *a, const void *b)
@@ -183,6 +189,10 @@ void EnumGenerator::GenerateEnumDescriptor(io::Printer* printer) {
   vars["shortname"] = descriptor_->name();
   vars["packagename"] = descriptor_->file()->package();
   vars["value_count"] = SimpleItoa(descriptor_->value_count());
+
+  bool lite_runtime = descriptor_->file()->options().has_optimize_for() &&
+    descriptor_->file()->options().optimize_for() ==
+    FileOptions_OptimizeMode_LITE_RUNTIME;
 
   // Sort by name and value, dropping duplicate values if they appear later.
   // TODO: use a c++ paradigm for this!
@@ -216,13 +226,13 @@ void EnumGenerator::GenerateEnumDescriptor(io::Printer* printer) {
 
   vars["unique_value_count"] = SimpleItoa(n_unique_values);
   printer->Print(vars,
-    "static const ProtobufCEnumValue $lcclassname$__enum_values_by_number[$unique_value_count$] =\n"
-    "{\n");
+      "static const ProtobufCEnumValue $lcclassname$__enum_values_by_number[$unique_value_count$] =\n"
+      "{\n");
   if (descriptor_->value_count() > 0) {
     GenerateValueInitializer(printer, value_index[0].index);
     for (int j = 1; j < descriptor_->value_count(); j++) {
       if (value_index[j-1].value != value_index[j].value) {
-	GenerateValueInitializer(printer, value_index[j].index);
+        GenerateValueInitializer(printer, value_index[j].index);
       }
     }
   }
@@ -236,64 +246,81 @@ void EnumGenerator::GenerateEnumDescriptor(io::Printer* printer) {
     int last_value = range_start_value;
     for (int j = 1; j < descriptor_->value_count(); j++) {
       if (value_index[j-1].value != value_index[j].value) {
-	if (last_value + 1 == value_index[j].value) {
-	  range_len++;
-	} else {
-	  // output range
-	  vars["range_start_value"] = SimpleItoa(range_start_value);
-	  vars["orig_index"] = SimpleItoa(range_start);
-	  printer->Print (vars, "{$range_start_value$, $orig_index$},");
-	  range_start_value = value_index[j].value;
-	  range_start += range_len;
-	  range_len = 1;
-	  n_ranges++;
-	}
-	last_value = value_index[j].value;
+        if (last_value + 1 == value_index[j].value) {
+          range_len++;
+        } else {
+          // output range
+          vars["range_start_value"] = SimpleItoa(range_start_value);
+          vars["orig_index"] = SimpleItoa(range_start);
+          printer->Print (vars, "{$range_start_value$, $orig_index$},");
+          range_start_value = value_index[j].value;
+          range_start += range_len;
+          range_len = 1;
+          n_ranges++;
+        }
+        last_value = value_index[j].value;
       }
     }
     {
-    vars["range_start_value"] = SimpleItoa(range_start_value);
-    vars["orig_index"] = SimpleItoa(range_start);
-    printer->Print (vars, "{$range_start_value$, $orig_index$},");
-    range_start += range_len;
-    n_ranges++;
+      vars["range_start_value"] = SimpleItoa(range_start_value);
+      vars["orig_index"] = SimpleItoa(range_start);
+      printer->Print (vars, "{$range_start_value$, $orig_index$},");
+      range_start += range_len;
+      n_ranges++;
     }
     {
-    vars["range_start_value"] = SimpleItoa(0);
-    vars["orig_index"] = SimpleItoa(range_start);
-    printer->Print (vars, "{$range_start_value$, $orig_index$}\n};\n");
+      vars["range_start_value"] = SimpleItoa(0);
+      vars["orig_index"] = SimpleItoa(range_start);
+      printer->Print (vars, "{$range_start_value$, $orig_index$}\n};\n");
     }
   }
   vars["n_ranges"] = SimpleItoa(n_ranges);
 
-  qsort(value_index, descriptor_->value_count(),
+  if (!lite_runtime) {
+    qsort(value_index, descriptor_->value_count(),
         sizeof(ValueIndex), compare_value_indices_by_name);
-  printer->Print(vars,
-    "static const ProtobufCEnumValueIndex $lcclassname$__enum_values_by_name[$value_count$] =\n"
-    "{\n");
-  for (int j = 0; j < descriptor_->value_count(); j++) {
-    vars["index"] = SimpleItoa(value_index[j].final_index);
-    vars["name"] = value_index[j].name;
-    printer->Print (vars, "  { \"$name$\", $index$ },\n");
+    printer->Print(vars,
+        "static const ProtobufCEnumValueIndex $lcclassname$__enum_values_by_name[$value_count$] =\n"
+        "{\n");
+    for (int j = 0; j < descriptor_->value_count(); j++) {
+      vars["index"] = SimpleItoa(value_index[j].final_index);
+      vars["name"] = value_index[j].name;
+      printer->Print (vars, "  { \"$name$\", $index$ },\n");
+    }
+    printer->Print(vars, "};\n");
   }
-  printer->Print(vars, "};\n");
 
-  printer->Print(vars,
-    "const ProtobufCEnumDescriptor $lcclassname$__descriptor =\n"
-    "{\n"
-    "  PROTOBUF_C__ENUM_DESCRIPTOR_MAGIC,\n"
-    "  \"$fullname$\",\n"
-    "  \"$shortname$\",\n"
-    "  \"$cname$\",\n"
-    "  \"$packagename$\",\n"
-    "  $unique_value_count$,\n"
-    "  $lcclassname$__enum_values_by_number,\n"
-    "  $value_count$,\n"
-    "  $lcclassname$__enum_values_by_name,\n"
-    "  $n_ranges$,\n"
-    "  $lcclassname$__value_ranges,\n"
-    "  NULL,NULL,NULL,NULL   /* reserved[1234] */\n"
-    "};\n");
+  if (lite_runtime) {
+    printer->Print(vars,
+        "const ProtobufCEnumDescriptor $lcclassname$__descriptor =\n"
+        "{\n"
+        "  PROTOBUF_C__ENUM_DESCRIPTOR_MAGIC,\n"
+        "  NULL,NULL,NULL,NULL, /* LITE_RUNTIME */\n"
+        "  $unique_value_count$,\n"
+        "  $lcclassname$__enum_values_by_number,\n"
+        "  0, NULL, /* LITE_RUNTIME */\n"
+        "  $n_ranges$,\n"
+        "  $lcclassname$__value_ranges,\n"
+        "  NULL,NULL,NULL,NULL   /* reserved[1234] */\n"
+        "};\n");
+  } else {
+    printer->Print(vars,
+        "const ProtobufCEnumDescriptor $lcclassname$__descriptor =\n"
+        "{\n"
+        "  PROTOBUF_C__ENUM_DESCRIPTOR_MAGIC,\n"
+        "  \"$fullname$\",\n"
+        "  \"$shortname$\",\n"
+        "  \"$cname$\",\n"
+        "  \"$packagename$\",\n"
+        "  $unique_value_count$,\n"
+        "  $lcclassname$__enum_values_by_number,\n"
+        "  $value_count$,\n"
+        "  $lcclassname$__enum_values_by_name,\n"
+        "  $n_ranges$,\n"
+        "  $lcclassname$__value_ranges,\n"
+        "  NULL,NULL,NULL,NULL   /* reserved[1234] */\n"
+        "};\n");
+  }
 
   delete[] value_index;
   delete[] name_index;

--- a/protoc-c/c_enum.cc
+++ b/protoc-c/c_enum.cc
@@ -150,14 +150,14 @@ void EnumGenerator::GenerateValueInitializer(io::Printer *printer, int index)
 {
   const EnumValueDescriptor *vd = descriptor_->value(index);
   map<string, string> vars;
-  bool lite_runtime = descriptor_->file()->options().has_optimize_for() &&
+  bool optimize_code_size = descriptor_->file()->options().has_optimize_for() &&
     descriptor_->file()->options().optimize_for() ==
-    FileOptions_OptimizeMode_LITE_RUNTIME;
+    FileOptions_OptimizeMode_CODE_SIZE;
   vars["enum_value_name"] = vd->name();
   vars["c_enum_value_name"] = FullNameToUpper(descriptor_->full_name()) + "__" + vd->name();
   vars["value"] = SimpleItoa(vd->number());
-  if (lite_runtime)
-    printer->Print(vars, "  { NULL, NULL, $value$ }, /* LITE_RUNTIME */\n");
+  if (optimize_code_size)
+    printer->Print(vars, "  { NULL, NULL, $value$ }, /* CODE_SIZE */\n");
   else
     printer->Print(vars,
         "  { \"$enum_value_name$\", \"$c_enum_value_name$\", $value$ },\n");
@@ -190,9 +190,9 @@ void EnumGenerator::GenerateEnumDescriptor(io::Printer* printer) {
   vars["packagename"] = descriptor_->file()->package();
   vars["value_count"] = SimpleItoa(descriptor_->value_count());
 
-  bool lite_runtime = descriptor_->file()->options().has_optimize_for() &&
+  bool optimize_code_size = descriptor_->file()->options().has_optimize_for() &&
     descriptor_->file()->options().optimize_for() ==
-    FileOptions_OptimizeMode_LITE_RUNTIME;
+    FileOptions_OptimizeMode_CODE_SIZE;
 
   // Sort by name and value, dropping duplicate values if they appear later.
   // TODO: use a c++ paradigm for this!
@@ -276,7 +276,7 @@ void EnumGenerator::GenerateEnumDescriptor(io::Printer* printer) {
   }
   vars["n_ranges"] = SimpleItoa(n_ranges);
 
-  if (!lite_runtime) {
+  if (!optimize_code_size) {
     qsort(value_index, descriptor_->value_count(),
         sizeof(ValueIndex), compare_value_indices_by_name);
     printer->Print(vars,
@@ -290,15 +290,15 @@ void EnumGenerator::GenerateEnumDescriptor(io::Printer* printer) {
     printer->Print(vars, "};\n");
   }
 
-  if (lite_runtime) {
+  if (optimize_code_size) {
     printer->Print(vars,
         "const ProtobufCEnumDescriptor $lcclassname$__descriptor =\n"
         "{\n"
         "  PROTOBUF_C__ENUM_DESCRIPTOR_MAGIC,\n"
-        "  NULL,NULL,NULL,NULL, /* LITE_RUNTIME */\n"
+        "  NULL,NULL,NULL,NULL, /* CODE_SIZE */\n"
         "  $unique_value_count$,\n"
         "  $lcclassname$__enum_values_by_number,\n"
-        "  0, NULL, /* LITE_RUNTIME */\n"
+        "  0, NULL, /* CODE_SIZE */\n"
         "  $n_ranges$,\n"
         "  $lcclassname$__value_ranges,\n"
         "  NULL,NULL,NULL,NULL   /* reserved[1234] */\n"

--- a/protoc-c/c_field.cc
+++ b/protoc-c/c_field.cc
@@ -139,9 +139,15 @@ void FieldGenerator::GenerateDescriptorInitializerGeneric(io::Printer* printer,
   if (oneof != NULL)
     variables["flags"] += " | PROTOBUF_C_FIELD_FLAG_ONEOF";
 
+  printer->Print("{\n");
+  if (descriptor_->file()->options().has_optimize_for() &&
+        descriptor_->file()->options().optimize_for() ==
+        FileOptions_OptimizeMode_LITE_RUNTIME) {
+     printer->Print("  NULL, /* LITE_RUNTIME */\n");
+  } else {
+     printer->Print(variables, "  \"$proto_name$\",\n");
+  }
   printer->Print(variables,
-    "{\n"
-    "  \"$proto_name$\",\n"
     "  $value$,\n"
     "  PROTOBUF_C_LABEL_$LABEL$,\n"
     "  PROTOBUF_C_TYPE_$TYPE$,\n");

--- a/protoc-c/c_field.cc
+++ b/protoc-c/c_field.cc
@@ -142,8 +142,8 @@ void FieldGenerator::GenerateDescriptorInitializerGeneric(io::Printer* printer,
   printer->Print("{\n");
   if (descriptor_->file()->options().has_optimize_for() &&
         descriptor_->file()->options().optimize_for() ==
-        FileOptions_OptimizeMode_LITE_RUNTIME) {
-     printer->Print("  NULL, /* LITE_RUNTIME */\n");
+        FileOptions_OptimizeMode_CODE_SIZE) {
+     printer->Print("  NULL, /* CODE_SIZE */\n");
   } else {
      printer->Print(variables, "  \"$proto_name$\",\n");
   }

--- a/protoc-c/c_message.cc
+++ b/protoc-c/c_message.cc
@@ -387,9 +387,9 @@ GenerateMessageDescriptor(io::Printer* printer) {
     vars["n_fields"] = SimpleItoa(descriptor_->field_count());
     vars["packagename"] = descriptor_->file()->package();
 
-    bool lite_runtime = descriptor_->file()->options().has_optimize_for() &&
+    bool optimize_code_size = descriptor_->file()->options().has_optimize_for() &&
         descriptor_->file()->options().optimize_for() ==
-        FileOptions_OptimizeMode_LITE_RUNTIME;
+        FileOptions_OptimizeMode_CODE_SIZE;
 
     for (int i = 0; i < descriptor_->nested_type_count(); i++) {
       nested_generators_[i]->GenerateMessageDescriptor(printer);
@@ -492,7 +492,7 @@ GenerateMessageDescriptor(io::Printer* printer) {
   printer->Outdent();
   printer->Print(vars, "};\n");
 
-  if (!lite_runtime) {
+  if (!optimize_code_size) {
     NameIndex *field_indices = new NameIndex [descriptor_->field_count()];
     for (int i = 0; i < descriptor_->field_count(); i++) {
       field_indices[i].name = sorted_fields[i]->name().c_str();
@@ -537,8 +537,8 @@ GenerateMessageDescriptor(io::Printer* printer) {
       "const ProtobufCMessageDescriptor $lcclassname$__descriptor =\n"
       "{\n"
       "  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,\n");
-  if (lite_runtime) {
-    printer->Print("  NULL,NULL,NULL,NULL, /* LITE_RUNTIME */\n");
+  if (optimize_code_size) {
+    printer->Print("  NULL,NULL,NULL,NULL, /* CODE_SIZE */\n");
   } else {
     printer->Print(vars,
         "  \"$fullname$\",\n"
@@ -550,8 +550,8 @@ GenerateMessageDescriptor(io::Printer* printer) {
       "  sizeof($classname$),\n"
       "  $n_fields$,\n"
       "  $lcclassname$__field_descriptors,\n");
-  if (lite_runtime) {
-    printer->Print("  NULL, /* LITE_RUNTIME */\n");
+  if (optimize_code_size) {
+    printer->Print("  NULL, /* CODE_SIZE */\n");
   } else {
     printer->Print(vars,
         "  $lcclassname$__field_indices_by_name,\n");

--- a/protoc-c/c_service.cc
+++ b/protoc-c/c_service.cc
@@ -198,9 +198,9 @@ void ServiceGenerator::GenerateServiceDescriptor(io::Printer* printer)
   int n_methods = descriptor_->method_count();
   MethodIndexAndName *mi_array = new MethodIndexAndName[n_methods];
 
-  bool lite_runtime = descriptor_->file()->options().has_optimize_for() &&
+  bool optimize_code_size = descriptor_->file()->options().has_optimize_for() &&
     descriptor_->file()->options().optimize_for() ==
-    FileOptions_OptimizeMode_LITE_RUNTIME;
+    FileOptions_OptimizeMode_CODE_SIZE;
 
   vars_["n_methods"] = SimpleItoa(n_methods);
   printer->Print(vars_, "static const ProtobufCMethodDescriptor $lcfullname$__method_descriptors[$n_methods$] =\n"
@@ -210,9 +210,9 @@ void ServiceGenerator::GenerateServiceDescriptor(io::Printer* printer)
     vars_["method"] = method->name();
     vars_["input_descriptor"] = "&" + FullNameToLower(method->input_type()->full_name()) + "__descriptor";
     vars_["output_descriptor"] = "&" + FullNameToLower(method->output_type()->full_name()) + "__descriptor";
-    if (lite_runtime) {
+    if (optimize_code_size) {
       printer->Print(vars_,
-          "  { NULL, $input_descriptor$, $output_descriptor$ }, /* LITE_RUNTIME */\n");
+          "  { NULL, $input_descriptor$, $output_descriptor$ }, /* CODE_SIZE */\n");
     } else {
       printer->Print(vars_,
           "  { \"$method$\", $input_descriptor$, $output_descriptor$ },\n");
@@ -222,7 +222,7 @@ void ServiceGenerator::GenerateServiceDescriptor(io::Printer* printer)
   }
   printer->Print(vars_, "};\n");
 
-  if (!lite_runtime) {
+  if (!optimize_code_size) {
     qsort ((void*)mi_array, n_methods, sizeof (MethodIndexAndName),
         compare_method_index_and_name_by_name);
     printer->Print(vars_, "const unsigned $lcfullname$__method_indices_by_name[] = {\n");
@@ -236,14 +236,14 @@ void ServiceGenerator::GenerateServiceDescriptor(io::Printer* printer)
     vars_["name"] = descriptor_->name();
   }
 
-  if (lite_runtime) {
+  if (optimize_code_size) {
     printer->Print(vars_, "const ProtobufCServiceDescriptor $lcfullname$__descriptor =\n"
         "{\n"
         "  PROTOBUF_C__SERVICE_DESCRIPTOR_MAGIC,\n"
-        "  NULL,NULL,NULL,NULL, /* LITE_RUNTIME */\n"
+        "  NULL,NULL,NULL,NULL, /* CODE_SIZE */\n"
         "  $n_methods$,\n"
         "  $lcfullname$__method_descriptors,\n"
-        "  NULL /* LITE_RUNTIME */\n"
+        "  NULL /* CODE_SIZE */\n"
         "};\n");
   } else {
     printer->Print(vars_, "const ProtobufCServiceDescriptor $lcfullname$__descriptor =\n"

--- a/t/generated-code2/test-generated-code2.c
+++ b/t/generated-code2/test-generated-code2.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "t/test-full.pb-c.h"
+#include "t/test-optimized.pb-c.h"
 #include "t/generated-code2/test-full-cxx-output.inc"
 
 #define TEST_ENUM_SMALL_TYPE_NAME   Foo__TestEnumSmall
@@ -1565,9 +1566,10 @@ test_enum_descriptor (const ProtobufCEnumDescriptor *desc)
       const ProtobufCEnumValue *vv;
       const ProtobufCEnumValue *vn;
       vv = protobuf_c_enum_descriptor_get_value (desc, sv->value);
-      vn = protobuf_c_enum_descriptor_get_value_by_name (desc, sv->name);
       assert (sv == vv);
-      assert (sv == vn);
+      vn = protobuf_c_enum_descriptor_get_value_by_name (desc, sv->name);
+      if (sv->name != NULL)
+         assert (sv == vn);
     }
   for (i = 0; i < desc->n_value_names; i++)
     {
@@ -1589,11 +1591,30 @@ test_enum_by_name (const ProtobufCEnumDescriptor *desc,
 }
 
 static void
+test_lite_enum (void)
+{
+  const ProtobufCEnumDescriptor *desc = &foo__test_enum_lite__descriptor;
+  const ProtobufCEnumValue *v;
+
+  v = protobuf_c_enum_descriptor_get_value_by_name (desc, "BOO");
+  assert (v == NULL);
+
+  v = protobuf_c_enum_descriptor_get_value (desc, 0);
+  assert (v != NULL);
+  assert (v->value == 0);
+
+  v = protobuf_c_enum_descriptor_get_value (desc, 3);
+  assert (v == NULL);
+}
+
+static void
 test_enum_lookups (void)
 {
   test_enum_descriptor (&foo__test_enum__descriptor);
   test_enum_descriptor (&foo__test_enum_small__descriptor);
   test_enum_descriptor (&foo__test_enum_dup_values__descriptor);
+  test_enum_descriptor (&foo__test_enum_lite__descriptor);
+  test_lite_enum ();
 #define TEST_ENUM_DUP_VALUES(str, shortname) \
   test_enum_by_name (&foo__test_enum_dup_values__descriptor,  \
                      str, FOO__TEST_ENUM_DUP_VALUES__##shortname)
@@ -1618,9 +1639,10 @@ test_message_descriptor (const ProtobufCMessageDescriptor *desc)
       const ProtobufCFieldDescriptor *fv;
       const ProtobufCFieldDescriptor *fn;
       fv = protobuf_c_message_descriptor_get_field (desc, f->id);
-      fn = protobuf_c_message_descriptor_get_field_by_name (desc, f->name);
       assert (f == fv);
-      assert (f == fn);
+      fn = protobuf_c_message_descriptor_get_field_by_name (desc, f->name);
+      if (desc->fields_sorted_by_name != NULL)
+        assert (f == fn);
     }
 }
 static void
@@ -1629,6 +1651,7 @@ test_message_lookups (void)
   test_message_descriptor (&foo__test_mess__descriptor);
   test_message_descriptor (&foo__test_mess_optional__descriptor);
   test_message_descriptor (&foo__test_mess_required_enum__descriptor);
+  test_message_descriptor (&foo__test_mess_lite__descriptor);
 }
 
 static void

--- a/t/test-optimized.proto
+++ b/t/test-optimized.proto
@@ -1,0 +1,13 @@
+package foo;
+
+option optimize_for = LITE_RUNTIME;
+
+enum TestEnumLite {
+  LITE = 0;
+  LITE1 = 1;
+}
+
+message TestMessLite {
+  required int32 field1 = 1;
+  required TestEnumLite field2 = 2;
+}

--- a/t/test-optimized.proto
+++ b/t/test-optimized.proto
@@ -1,6 +1,6 @@
 package foo;
 
-option optimize_for = LITE_RUNTIME;
+option optimize_for = CODE_SIZE;
 
 enum TestEnumLite {
   LITE = 0;


### PR DESCRIPTION
Adds support for the `LITE_RUNTIME` optimization option to the protobuf-c
compiler. Enabling this option would generate lighter weight message,
enum, and service descriptors that contain NO strings. As a result,
calls to lookup descriptors via the `*_get_{field,value,method}_by_name`
API will return `NULL`.

Default compiler behavior (when optimize_for is not specified or is not
set to `LITE_RUNTIME`) is unchanged.

This option is useful for various reasons:
1. Projects with a large number of structures and enums defined using .proto files will see a significant code size reduction when using the `LITE_RUNTIME` option with protobuf-c since descriptors will take up less space.
2. For security reasons when the exposure of enum or message names in the object code is not desirable.

One con is the inability to perform string-based lookups on descriptors generated using the `LITE_RUNTIME` option, affecting debuggability, but having the option control this behavior probably gives the developers enough flexibility.

There is a question of whether `LITE_RUNTIME` is the correct option to use for this feature. `optimize_for = CODE_SIZE` may be appropriate as well, but since the lookup-by-name feature doesn't really work with this change I figured `LITE_RUNTIME` describes the behavior better.