### PR TITLE
Fix compile errors on MSVC caused by {} initializaton

### DIFF
--- a/protoc-c/c_message.cc
+++ b/protoc-c/c_message.cc
@@ -237,7 +237,7 @@ GenerateStructDefinition(io::Printer* printer) {
     // Initialize the case enum
     printer->Print(vars, ", $foneofname$__NOT_SET");
     // Initialize the enum
-    printer->Print(", {}");
+    printer->Print(", 0");
   }
   printer->Print(" }\n\n\n");
 


### PR DESCRIPTION
I was compiling latest protobuf-c with Visual Studio on Windows and got multiple errors in ``test-generated-code2.c`` caused by ``{}`` in initialization:

test-full.pb-c.h was generated as
```C
...
struct  _Foo__TestMessOneof
{
  ProtobufCMessage base;
  protobuf_c_boolean has_opt_int;
  int32_t opt_int;
  Foo__TestMessOneof__TestOneofCase test_oneof_case;
  union {
    int32_t test_int32;
    int32_t test_sint32;
    int32_t test_sfixed32;
    int64_t test_int64;
    int64_t test_sint64;
    int64_t test_sfixed64;
    uint32_t test_uint32;
    uint32_t test_fixed32;
    uint64_t test_uint64;
    uint64_t test_fixed64;
    float test_float;
    double test_double;
    protobuf_c_boolean test_boolean;
    Foo__TestEnumSmall test_enum_small;
    Foo__TestEnum test_enum;
    char *test_string;
    ProtobufCBinaryData test_bytes;
    Foo__SubMess *test_message;
  };
};

#define FOO__TEST_MESS_ONEOF__INIT \
 { PROTOBUF_C_MESSAGE_INIT (&foo__test_mess_oneof__descriptor) \
    , 0,0, FOO__TEST_MESS_ONEOF__TEST_ONEOF__NOT_SET, {} }
...
```
and this ``{}`` was causing syntax error. When I repalced it with ``0`` in the generator the generated code was
```
#define FOO__TEST_MESS_ONEOF__INIT \
 { PROTOBUF_C_MESSAGE_INIT (&foo__test_mess_oneof__descriptor) \
    , 0,0, FOO__TEST_MESS_ONEOF__TEST_ONEOF__NOT_SET, 0 }
```
Compilation errors vanished and the tests passed (MSVC is not fully C99, even Visual Studio 2015 RC I used)

Not sure this is this a correct fix. Can anyone help? 

 