### PR TITLE
Update link to Autotools Mythbuster to canonical site

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If using autotools, the `PKG_CHECK_MODULES` macro can be used to detect the pres
 
     PKG_CHECK_MODULES([PROTOBUF_C], [libprotobuf-c >= 1.0.0])
 
-This will place compiler flags in the `PROTOBUF_C_CFLAGS` variable and linker flags in the `PROTOBUF_C_LDFLAGS` variable. Read [more information here](https://www.flameeyes.eu/autotools-mythbuster/pkgconfig/pkg_check_modules.html) about the `PKG_CHECK_MODULES` macro.
+This will place compiler flags in the `PROTOBUF_C_CFLAGS` variable and linker flags in the `PROTOBUF_C_LDFLAGS` variable. Read [more information here](https://autotools.io/pkgconfig/pkg_check_modules.html) about the `PKG_CHECK_MODULES` macro.
 
 ## Versioning
 


### PR DESCRIPTION
I've moved the guide to its own domain some time ago, fix the reference to avoid the redirects.