### PR TITLE
Fix -Wsign-compare warnings

### DIFF
--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -285,13 +285,13 @@ int32_size(int32_t v)
 {
 	if (v < 0) {
 		return 10;
-	} else if (v < (1UL << 7)) {
+	} else if (v < (1L << 7)) {
 		return 1;
-	} else if (v < (1UL << 14)) {
+	} else if (v < (1L << 14)) {
 		return 2;
-	} else if (v < (1UL << 21)) {
+	} else if (v < (1L << 21)) {
 		return 3;
-	} else if (v < (1UL << 28)) {
+	} else if (v < (1L << 28)) {
 		return 4;
 	} else {
 		return 5;


### PR DESCRIPTION
```
make protobuf-c/libprotobuf-c.la CFLAGS="-Wsign-compare"
```

This produces several warnings like these:

```
warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
```