### PR TITLE
proto3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
             - ubuntu-toolchain-r-test
 env:
     global:
-        - PROTOBUF_VERSION=2.6.1
+        - PROTOBUF_VERSION=3.0.2
         - PKG_CONFIG_PATH=$HOME/protobuf-$PROTOBUF_VERSION-bin/lib/pkgconfig
 
 before_install:
@@ -44,9 +44,9 @@ before_install:
 
 install:
     - pip install --user cpp-coveralls
-    - wget https://github.com/google/protobuf/releases/download/v$PROTOBUF_VERSION/protobuf-$PROTOBUF_VERSION.tar.gz
-    - tar xf protobuf-$PROTOBUF_VERSION.tar.gz
-    - ( cd protobuf-$PROTOBUF_VERSION && ./configure --prefix=$HOME/protobuf-$PROTOBUF_VERSION-bin && make -j2 && make install )
+    - wget https://github.com/google/protobuf/archive/v$PROTOBUF_VERSION.tar.gz
+    - tar xf v$PROTOBUF_VERSION.tar.gz
+    - ( cd protobuf-$PROTOBUF_VERSION && ./autogen.sh && ./configure --prefix=$HOME/protobuf-$PROTOBUF_VERSION-bin && make -j2 && make install )
 
 script:
     - ./autogen.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -185,6 +185,29 @@ BUILT_SOURCES += \
 	t/test-full.pb.cc t/test-full.pb.h \
 	t/generated-code2/test-full-cxx-output.inc
 
+if BUILD_PROTO3
+
+check_PROGRAMS += \
+	t/generated-code3/test-generated-code3
+
+TESTS += \
+	t/generated-code3/test-generated-code3
+
+t_generated_code3_test_generated_code3_LDADD = \
+	protobuf-c/libprotobuf-c.la
+
+t_generated_code3_test_generated_code3_SOURCES = \
+	t/generated-code/test-generated-code.c \
+	t/test-proto3.pb-c.c
+
+t/test-proto3.pb-c.c t/test-proto3.pb-c.h: $(top_builddir)/protoc-c/protoc-gen-c$(EXEEXT) $(top_srcdir)/t/test-proto3.proto
+	$(AM_V_GEN)@PROTOC@ --plugin=$(top_builddir)/protoc-c/protoc-gen-c$(EXEEXT) -I$(top_srcdir) --c_out=$(top_builddir) $(top_srcdir)/t/test-proto3.proto
+
+BUILT_SOURCES += \
+	t/test-proto3.pb-c.c t/test-proto3.pb-c.h
+
+endif # BUILD_PROTO3
+
 t_version_version_SOURCES = \
 	t/version/version.c
 t_version_version_LDADD = \
@@ -197,6 +220,7 @@ EXTRA_DIST += \
 	t/test.proto \
 	t/test-full.proto \
 	t/test-optimized.proto \
+	t/test-proto3.proto \
 	t/generated-code2/common-test-arrays.h
 
 #

--- a/configure.ac
+++ b/configure.ac
@@ -43,11 +43,17 @@ if test -n "$PKG_CONFIG"; then
     fi
 fi
 
+proto3_supported="no"
+
 AC_ARG_ENABLE([protoc],
   AS_HELP_STRING([--disable-protoc], [Disable building protoc_c (also disables tests)]))
 if test "x$enable_protoc" != "xno"; then
   AC_LANG_PUSH([C++])
-  PKG_CHECK_MODULES([protobuf], [protobuf >= 2.6.0])
+
+  PKG_CHECK_MODULES([protobuf], [protobuf >= 3.0.0],
+    [proto3_supported=yes],
+    [PKG_CHECK_MODULES([protobuf], [protobuf >= 2.6.0])]
+  )
 
   save_CPPFLAGS="$CPPFLAGS"
   CPPFLAGS="$save_CPPFLAGS $protobuf_CFLAGS"
@@ -62,12 +68,18 @@ if test "x$enable_protoc" != "xno"; then
   if test -z "$PROTOC"; then
     AC_MSG_ERROR([Please install the protobuf compiler from https://code.google.com/p/protobuf/.])
   fi
+
   PROTOBUF_VERSION="$($PROTOC --version)"
+
 else
   PROTOBUF_VERSION="not required, not building compiler"
 fi
+
 AM_CONDITIONAL([BUILD_COMPILER], [test "x$enable_protoc" != "xno"])
+AM_CONDITIONAL([BUILD_PROTO3], [test "x$proto3_supported" != "xno"])
 AM_CONDITIONAL([CROSS_COMPILING], [test "x$cross_compiling" != "xno"])
+
+AM_COND_IF([BUILD_PROTO3], [AC_DEFINE([HAVE_PROTO3], [1], [Support proto3 syntax])])
 
 gl_LD_VERSION_SCRIPT
 

--- a/protobuf-c/protobuf-c.h
+++ b/protobuf-c/protobuf-c.h
@@ -284,6 +284,12 @@ typedef enum {
 	 * preserved.
 	 */
 	PROTOBUF_C_LABEL_REPEATED,
+
+	/**
+	 * This field has no label. This is valid  only in proto3 and is
+	 * equivalent to OPTIONAL but no "has" quantifier will be consulted.
+	 */
+	PROTOBUF_C_LABEL_NONE,
 } ProtobufCLabel;
 
 /**

--- a/protoc-c/c_bytes_field.cc
+++ b/protoc-c/c_bytes_field.cc
@@ -101,7 +101,7 @@ void BytesFieldGenerator::GenerateStructMembers(io::Printer* printer) const
       printer->Print(variables_, "ProtobufCBinaryData $name$$deprecated$;\n");
       break;
     case FieldDescriptor::LABEL_OPTIONAL:
-      if (descriptor_->containing_oneof() == NULL)
+      if (descriptor_->containing_oneof() == NULL && FieldSyntax(descriptor_) == 2)
         printer->Print(variables_, "protobuf_c_boolean has_$name$$deprecated$;\n");
       printer->Print(variables_, "ProtobufCBinaryData $name$$deprecated$;\n");
       break;
@@ -142,7 +142,9 @@ void BytesFieldGenerator::GenerateStaticInit(io::Printer* printer) const
       printer->Print(variables_, "$default_value$");
       break;
     case FieldDescriptor::LABEL_OPTIONAL:
-      printer->Print(variables_, "0,$default_value$");
+      if (FieldSyntax(descriptor_) == 2)
+        printer->Print(variables_, "0, ");
+      printer->Print(variables_, "$default_value$");
       break;
     case FieldDescriptor::LABEL_REPEATED:
       // no support for default?

--- a/protoc-c/c_enum_field.cc
+++ b/protoc-c/c_enum_field.cc
@@ -103,7 +103,7 @@ void EnumFieldGenerator::GenerateStructMembers(io::Printer* printer) const
       printer->Print(variables_, "$type$ $name$$deprecated$;\n");
       break;
     case FieldDescriptor::LABEL_OPTIONAL:
-      if (descriptor_->containing_oneof() == NULL)
+      if (descriptor_->containing_oneof() == NULL && FieldSyntax(descriptor_) == 2)
         printer->Print(variables_, "protobuf_c_boolean has_$name$$deprecated$;\n");
       printer->Print(variables_, "$type$ $name$$deprecated$;\n");
       break;
@@ -125,7 +125,9 @@ void EnumFieldGenerator::GenerateStaticInit(io::Printer* printer) const
       printer->Print(variables_, "$default$");
       break;
     case FieldDescriptor::LABEL_OPTIONAL:
-      printer->Print(variables_, "0,$default$");
+      if (FieldSyntax(descriptor_) == 2)
+        printer->Print(variables_, "0, ");
+      printer->Print(variables_, "$default$");
       break;
     case FieldDescriptor::LABEL_REPEATED:
       // no support for default?

--- a/protoc-c/c_field.cc
+++ b/protoc-c/c_field.cc
@@ -107,7 +107,6 @@ void FieldGenerator::GenerateDescriptorInitializerGeneric(io::Printer* printer,
 							  const string &descriptor_addr) const
 {
   map<string, string> variables;
-  variables["LABEL"] = CamelToUpper(GetLabelName(descriptor_->label()));
   variables["TYPE"] = type_macro;
   variables["classname"] = FullNameToC(FieldScope(descriptor_)->full_name());
   variables["name"] = FieldName(descriptor_);
@@ -117,6 +116,14 @@ void FieldGenerator::GenerateDescriptorInitializerGeneric(io::Printer* printer,
   const OneofDescriptor *oneof = descriptor_->containing_oneof();
   if (oneof != NULL)
     variables["oneofname"] = FullNameToLower(oneof->name());
+
+  if (FieldSyntax(descriptor_) == 3 &&
+    descriptor_->label() == FieldDescriptor::LABEL_OPTIONAL) {
+    variables["LABEL"] = "NONE";
+    optional_uses_has = false;
+  } else {
+    variables["LABEL"] = CamelToUpper(GetLabelName(descriptor_->label()));
+  }
 
   if (descriptor_->has_default_value()) {
     variables["default_value"] = string("&")

--- a/protoc-c/c_helpers.h
+++ b/protoc-c/c_helpers.h
@@ -179,6 +179,16 @@ struct NameIndex
 };
 int compare_name_indices_by_name(const void*, const void*);
 
+// Return the syntax version of the file containing the field.
+// This wrapper is needed to be able to compile against protobuf2.
+inline int FieldSyntax(const FieldDescriptor* field) {
+#ifdef HAVE_PROTO3
+  return field->file()->syntax() == FileDescriptor::SYNTAX_PROTO3 ? 3 : 2;
+#else
+  return 2;
+#endif
+}
+
 }  // namespace c
 }  // namespace compiler
 }  // namespace protobuf

--- a/protoc-c/c_primitive_field.cc
+++ b/protoc-c/c_primitive_field.cc
@@ -113,7 +113,7 @@ void PrimitiveFieldGenerator::GenerateStructMembers(io::Printer* printer) const
       printer->Print(vars, "$c_type$ $name$$deprecated$;\n");
       break;
     case FieldDescriptor::LABEL_OPTIONAL:
-      if (descriptor_->containing_oneof() == NULL)
+      if (descriptor_->containing_oneof() == NULL && FieldSyntax(descriptor_) == 2)
         printer->Print(vars, "protobuf_c_boolean has_$name$$deprecated$;\n");
       printer->Print(vars, "$c_type$ $name$$deprecated$;\n");
       break;
@@ -160,7 +160,9 @@ void PrimitiveFieldGenerator::GenerateStaticInit(io::Printer* printer) const
       printer->Print(vars, "$default_value$");
       break;
     case FieldDescriptor::LABEL_OPTIONAL:
-      printer->Print(vars, "0,$default_value$");
+      if (FieldSyntax(descriptor_) == 2)
+        printer->Print(vars, "0, ");
+      printer->Print(vars, "$default_value$");
       break;
     case FieldDescriptor::LABEL_REPEATED:
       printer->Print("0,NULL");

--- a/t/test-proto3.proto
+++ b/t/test-proto3.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+
+package foo;
+
+message Person {
+  string name = 1;
+  int32 id = 2;
+  string email = 3;
+
+  enum PhoneType {
+    MOBILE = 0;
+    HOME = 1;
+    WORK = 2;
+  }
+
+  message PhoneNumber {
+    string number = 1;
+    PhoneType type = 2;
+  }
+
+  repeated PhoneNumber phone = 4;
+}
+
+message LookupResult
+{
+  Person person = 1;
+}
+
+message Name {
+  string name = 1;
+};
+
+service DirLookup {
+  rpc ByName (Name) returns (LookupResult);
+}


### PR DESCRIPTION
This is an experimental first cut at adding proto3 support and I have not
tested it further than porting to proto3 the testcase. Before pushing
this further I would like to have some feedback on whether I am on
the right track.

As far as I understand protobuf-c already has pretty much everything
needed once it is built using a new version of protibuf itself.
The only missing thing is that in proto3 all fields are optional and
having to manually set has_foo is inconvenient.

This patch special cases the proto3 syntax files so that structs for the
bytes, enum and primitive fields do not emit the has_ field.

It also adds PROTOBUF_C_LABEL_NONE to the label enum that is used for
proto3 fields. When a fields has this label, the quantifier is not
consulted and instead the field is packed/unpacked depending on
whether it has a value different from NULL/0.

The patch changes the generated-code test to proto3 as a quick test,
clearly this should not be part of the final patch.

The patch also slightly refactors packing/unpacking optional fields
so that the internal functions take a boolean istead of a pointer to
a boolean: casting in the caller seems cleaner to me... this part
can be dropped or split out in its own preliminary patch.
