### PR TITLE
protobuf-c: fix: make dist

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -198,7 +198,7 @@ EXTRA_DIST += \
 CLEANFILES += $(BUILT_SOURCES)
 
 dist-hook:
-	rm -vf `find $(top_distdir) -name '*.pb-c.[ch]' -o -name '*.pb.cc' -o -name '*.pb.h'`
+	rm -vf `find $(distdir) -name '*.pb-c.[ch]' -o -name '*.pb.cc' -o -name '*.pb.h'`
 
 install-data-hook:
 	$(MKDIR_P) $(DESTDIR)$(includedir)/google/protobuf-c


### PR DESCRIPTION
remove .pb.{cc,h} in distdir instead of top_distdir in order to
prevent removing files from other projects when protobuf-c is
included as an autotools subproject.