### PR TITLE
relax constraint from v2.64 -> v2.63 (so that it works on SL6)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_PREREQ(2.64)
+AC_PREREQ(2.63)
 
 AC_INIT([protobuf-c],
         [1.2.1],


### PR DESCRIPTION
Hello,

I'm part of a team working on a project that (I believe) would benefit greatly from protobuf-c. Part of our constraints are that we have to work on scientific linux 6, sadly, which is rather old:
* _uname_ outputs 2.6.32-642.1.1.el6.x86_64)
* _autom4te --version_ outputs autom4te (GNU Autoconf) 2.6**3**

My initial attempt to build the master protobuf-c branch failed - it reported that the autom4te version was too old (2.64 required, 2.63 found). I relaxed the constraint to 2.63 and protobuf-c builds fine on the target environment.

Would it be possible to relax the constraint from 2.64 -> 2.63 ?