### PR TITLE
rm argument fix for solaris

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -206,11 +206,11 @@ EXTRA_DIST += \
 CLEANFILES += $(BUILT_SOURCES)
 
 dist-hook:
-	rm -vf `find $(distdir) -name '*.pb-c.[ch]' -o -name '*.pb.cc' -o -name '*.pb.h'`
+	rm -f `find $(distdir) -name '*.pb-c.[ch]' -o -name '*.pb.cc' -o -name '*.pb.h'`
 
 install-data-hook:
 	$(MKDIR_P) $(DESTDIR)$(includedir)/google/protobuf-c
-	cd $(DESTDIR)$(includedir)/google/protobuf-c && rm -vf protobuf-c.h
+	cd $(DESTDIR)$(includedir)/google/protobuf-c && rm -f protobuf-c.h
 	cd $(DESTDIR)$(includedir)/google/protobuf-c && $(LN_S) ../../protobuf-c/protobuf-c.h protobuf-c.h
 
 #


### PR DESCRIPTION
Building on solaris fails since the `rm` command (at least on solaris 10) does not know the `-v` argument. This patch removes the argument.