### PR TITLE
make init_value const

### DIFF
--- a/protoc-c/c_message.cc
+++ b/protoc-c/c_message.cc
@@ -337,7 +337,7 @@ GenerateHelperFunctionDefinitions(io::Printer* printer, bool is_submessage)
 		 "void   $lcclassname$__init\n"
 		 "                     ($classname$         *message)\n"
 		 "{\n"
-		 "  static $classname$ init_value = $ucclassname$__INIT;\n"
+		 "  static const $classname$ init_value = $ucclassname$__INIT;\n"
 		 "  *message = init_value;\n"
 		 "}\n");
   if (!is_submessage) {


### PR DESCRIPTION
Making `init_value` `const` will (with typical compilers) remove the need to reserve space for a copy in the bss section since the value can not change and can directly be copied from the data section (where it is needed anyway).

This reduces the amount of needed memory by one message size (which might be relevant if there are a lot of different messages or there are large messages).
