### PR TITLE
Document and extend the effect of passing NULL to ..._free_unpacked functions

### DIFF
--- a/protobuf-c/protobuf-c.h
+++ b/protobuf-c/protobuf-c.h
@@ -956,7 +956,7 @@ protobuf_c_message_unpack(
  * protobuf_c_message_unpack().
  *
  * \param message
- *      The message object to free.
+ *      The message object to free. May be NULL.
  * \param allocator
  *      `ProtobufCAllocator` to use for memory deallocation. May be NULL to
  *      specify the default allocator.

--- a/protobuf-c/protobuf-c.h
+++ b/protobuf-c/protobuf-c.h
@@ -139,7 +139,7 @@ Foo__Bar__BazBah *
 ~~~
  *
  * - `free_unpacked()`. Frees a message object obtained with the `unpack()`
- *   method.
+ *   method. Freeing `NULL` is allowed (the same as with `free()`).
  *
 ~~~{.c}
 void   foo__bar__baz_bah__free_unpacked

--- a/protoc-c/c_message.cc
+++ b/protoc-c/c_message.cc
@@ -376,6 +376,8 @@ GenerateHelperFunctionDefinitions(io::Printer* printer, bool is_submessage)
 		 "                     ($classname$ *message,\n"
 		 "                      ProtobufCAllocator *allocator)\n"
 		 "{\n"
+		 "  if(!message)\n"
+		 "    return;\n"
 		 "  assert(message->base.descriptor == &$lcclassname$__descriptor);\n"
 		 "  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);\n"
 		 "}\n"

--- a/t/generated-code2/test-generated-code2.c
+++ b/t/generated-code2/test-generated-code2.c
@@ -2181,6 +2181,12 @@ test_message_check(void)
   assert(1 == protobuf_c_message_check(&m.base));
 }
 
+static void
+test_message_free_null (void)
+{
+  foo__sub_mess__free_unpacked (NULL, NULL);
+}
+
 /* === simple testing framework === */
 
 typedef void (*TestFunc) (void);
@@ -2316,6 +2322,8 @@ static Test tests[] =
   { "test field flags", test_field_flags },
 
   { "test message_check()", test_message_check },
+
+  { "test freeing NULL", test_message_free_null },
 };
 #define n_tests (sizeof(tests)/sizeof(Test))
 


### PR DESCRIPTION
For protobuf_c_message_free_unpacked() this just documents the existing behavior.

For the generated functions this causes them to do nothing when a null message pointer is supplied, aligning them with the behavior of free() and thus simplifying callers.