### PR TITLE
Remove leftover FIXME comment

### DIFF
--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -2165,7 +2165,7 @@ merge_messages(ProtobufCMessage *earlier_msg,
 				*p_earlier = 0;
 			}
 		} else if (fields[i].label == PROTOBUF_C_LABEL_OPTIONAL ||
-			   fields[i].label == PROTOBUF_C_LABEL_NONE) { // FIXME to check
+			   fields[i].label == PROTOBUF_C_LABEL_NONE) {
 			const ProtobufCFieldDescriptor *field;
 			uint32_t *earlier_case_p = STRUCT_MEMBER_PTR(uint32_t,
 								     earlier_msg,


### PR DESCRIPTION
Small fixup for https://github.com/protobuf-c/protobuf-c/pull/228

I had that FIXME because I was not 100% sure if in proto3 sub messages that are sent more than once should me merged or if they are invalid... Let's assume they are exactly the same as proto2 optional messages and remove the FIXME