### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/build-cmake/CMakeLists.txt
+++ b/build-cmake/CMakeLists.txt
@@ -9,6 +9,7 @@ PROJECT(protobuf-c)
 
 #options
 option(MSVC_STATIC_BUILD "MSVC_STATIC_BUILD" OFF)
+option(BUILD_PROTO3 "BUILD_PROTO3" ON)
 
 INCLUDE(TestBigEndian)
 TEST_BIG_ENDIAN(WORDS_BIGENDIAN)
@@ -18,7 +19,7 @@ ADD_DEFINITIONS(-DPACKAGE_VERSION="${PACKAGE_VERSION}")
 ADD_DEFINITIONS(-DPACKAGE_STRING="${PACKAGE_STRING}")
 ADD_DEFINITIONS(-DWORDS_BIGENDIAN=${WORDS_BIGENDIAN})
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+if(MSVC)
   # using Visual Studio C++
   SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4267 /wd4244")
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267 /wd4244")
@@ -41,6 +42,10 @@ INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}) # for generated files
 
 FIND_PACKAGE(Protobuf REQUIRED)
 INCLUDE_DIRECTORIES(${PROTOBUF_INCLUDE_DIR})
+
+if (BUILD_PROTO3)
+	ADD_DEFINITIONS(-DHAVE_PROTO3)
+endif()
 
 if (MSVC AND MSVC_STATIC_BUILD)
 	# In case we are building static libraries, link also the runtime library statically
@@ -67,24 +72,28 @@ ADD_CUSTOM_COMMAND(TARGET ${PROJECT_NAME} POST_BUILD
                    DEPENDS protoc-gen-c)
 ENDIF()
 
+FUNCTION(GENERATE_TEST_SOURCES PROTO_FILE SRC HDR)
+	ADD_CUSTOM_COMMAND(OUTPUT ${SRC} ${HDR}
+                   COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
+                   ARGS --plugin=$<TARGET_FILE:protoc-gen-c> -I${MAIN_DIR} ${PROTO_FILE} --c_out=${CMAKE_BINARY_DIR}
+                   DEPENDS protoc-gen-c)
+ENDFUNCTION()
+
+
 IF(CMAKE_BUILD_TYPE MATCHES Debug)
 ENABLE_TESTING()
-ADD_CUSTOM_COMMAND(OUTPUT t/test.pb-c.c t/test.pb-c.h
-                   COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
-                   ARGS --plugin=${CMAKE_CURRENT_BINARY_DIR}/protoc-gen-c -I${MAIN_DIR} ${TEST_DIR}/test.proto --c_out=${CMAKE_BINARY_DIR}
-                   DEPENDS protoc-gen-c)
+
+GENERATE_TEST_SOURCES(${TEST_DIR}/test.proto t/test.pb-c.c t/test.pb-c.h)
 
 ADD_EXECUTABLE(test-generated-code ${TEST_DIR}/generated-code/test-generated-code.c t/test.pb-c.c t/test.pb-c.h )
 TARGET_LINK_LIBRARIES(test-generated-code protobuf-c)
+
 
 ADD_CUSTOM_COMMAND(OUTPUT t/test-full.pb.cc t/test-full.pb.h
                    COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
                    ARGS --cpp_out ${CMAKE_BINARY_DIR} -I${MAIN_DIR} ${TEST_DIR}/test-full.proto)
 
-ADD_CUSTOM_COMMAND(OUTPUT t/test-full.pb-c.c t/test-full.pb-c.h
-                   COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
-                   ARGS --plugin=${CMAKE_CURRENT_BINARY_DIR}/protoc-gen-c -I${MAIN_DIR} ${TEST_DIR}/test-full.proto --c_out=${CMAKE_BINARY_DIR}
-                   DEPENDS protoc-gen-c)
+GENERATE_TEST_SOURCES(${TEST_DIR}/test-full.proto t/test-full.pb-c.c t/test-full.pb-c.h)
 
 ADD_EXECUTABLE(cxx-generate-packed-data ${TEST_DIR}/generated-code2/cxx-generate-packed-data.cc t/test-full.pb.h t/test-full.pb.cc)
 TARGET_LINK_LIBRARIES(cxx-generate-packed-data ${PROTOBUF_LIBRARY})
@@ -95,16 +104,28 @@ ADD_CUSTOM_COMMAND(OUTPUT t/generated-code2/test-full-cxx-output.inc
                    DEPENDS cxx-generate-packed-data
                    )
 
-ADD_CUSTOM_COMMAND(OUTPUT t/test-optimized.pb-c.c t/test-optimized.pb-c.h
-                   COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
-                   ARGS --plugin=${CMAKE_CURRENT_BINARY_DIR}/protoc-gen-c -I${MAIN_DIR} ${TEST_DIR}/test-optimized.proto --c_out=${CMAKE_BINARY_DIR}
-                   DEPENDS protoc-gen-c)
+GENERATE_TEST_SOURCES(${TEST_DIR}/test-optimized.proto t/test-optimized.pb-c.c t/test-optimized.pb-c.h)
 
 ADD_EXECUTABLE(test-generated-code2 ${TEST_DIR}/generated-code2/test-generated-code2.c t/generated-code2/test-full-cxx-output.inc t/test-full.pb-c.h t/test-full.pb-c.c t/test-optimized.pb-c.h t/test-optimized.pb-c.c)
 TARGET_LINK_LIBRARIES(test-generated-code2 protobuf-c)
 
+
+
+GENERATE_TEST_SOURCES(${TEST_DIR}/issue220/issue220.proto t/issue220/issue220.pb-c.c t/issue220/issue220.pb-c.h)
+ADD_EXECUTABLE(test-issue220 ${TEST_DIR}/issue220/issue220.c t/issue220/issue220.pb-c.c t/issue220/issue220.pb-c.h)
+TARGET_LINK_LIBRARIES(test-issue220 protobuf-c)
+
+GENERATE_TEST_SOURCES(${TEST_DIR}/issue251/issue251.proto t/issue251/issue251.pb-c.c t/issue251/issue251.pb-c.h)
+ADD_EXECUTABLE(test-issue251 ${TEST_DIR}/issue251/issue251.c t/issue251/issue251.pb-c.c t/issue251/issue251.pb-c.h)
+TARGET_LINK_LIBRARIES(test-issue251 protobuf-c)
+
 ADD_EXECUTABLE(test-version ${TEST_DIR}/version/version.c)
 TARGET_LINK_LIBRARIES(test-version protobuf-c)
+
+GENERATE_TEST_SOURCES(${TEST_DIR}/test-proto3.proto t/test-proto3.pb-c.c t/test-proto3.pb-c.h)
+ADD_EXECUTABLE(test-generated-code3 ${TEST_DIR}/generated-code/test-generated-code.c t/test-proto3.pb-c.c t/test-proto3.pb-c.h)
+TARGET_COMPILE_DEFINITIONS(test-generated-code3 PUBLIC -DPROTO3)
+TARGET_LINK_LIBRARIES(test-generated-code3 protobuf-c)
 
 ENDIF()
 
@@ -121,6 +142,9 @@ INCLUDE(Dart)
 SET(DART_TESTING_TIMEOUT 5)
 ADD_TEST(test-generated-code test-generated-code)
 ADD_TEST(test-generated-code2 test-generated-code2)
+ADD_TEST(test-generated-code3 test-generated-code3)
+ADD_TEST(test-issue220 test-issue220)
+ADD_TEST(test-issue251 test-issue251)
 ADD_TEST(test-version test-version)
 
 


### PR DESCRIPTION
Currently some build errors arise on Windows/cmake with Protobuf 3.2.0.
Main error was simple, the option
```
--plugin=${CMAKE_CURRENT_BINARY_DIR}/protoc-gen-c
```
missed .exe, so I have added ``$<TARGET_FILE:protoc-gen-c>``. Also introduced GENERATE_TEST_SOURCES macro to simplify test creation a little and tried to include all current tests.

However, test-generated-code3 keeps failing:
```
 Assertion failed: person2->id == 42, file E:\winbuilds_d\protobuf-c\t\generated-code\test-generated-code.c, line 53
```
Not sure if it is a build problem... 