### PR TITLE
Avoid 'unused label' compiler warning/error in big endian architectures

### DIFF
--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -1761,9 +1761,11 @@ pack_buffer_packed_payload(const ProtobufCFieldDescriptor *field,
 	}
 	return rv;
 
+#if !defined(WORDS_BIGENDIAN)
 no_packing_needed:
 	buffer->append(buffer, rv, array);
 	return rv;
+#endif
 }
 
 static size_t


### PR DESCRIPTION
protobuf-c.c: In function `pack_buffer_packed_payload':
protobuf-c.c:1770: warning: label `no_packing_needed' defined but not used

This warning is generated if the label is not wrapped.
