### PR TITLE
Fix compilation with upstream protobuf

### DIFF
--- a/protoc-c/c_helpers.h
+++ b/protoc-c/c_helpers.h
@@ -75,6 +75,12 @@ namespace protobuf {
 namespace compiler {
 namespace c {
 
+using std::back_insert_iterator;
+using std::map;
+using std::set;
+using std::string;
+using std::vector;
+
 // Returns the non-nested type name for the given type.  If "qualified" is
 // true, prefix the type with the full namespace.  For example, if you had:
 //   package foo.bar;


### PR DESCRIPTION
Starting with commit 7c76ac1735a3b8f4523856bbd67588b6ccc7f850 of
protobuf, we get this error :

c_helpers.cc: In function 'void google::protobuf::compiler::c::SplitStringUsing(const string&, const char*, std::vector<std::__cxx11::basic_string<char> >*)':
c_helpers.cc:507:3: error: 'back_insert_iterator' was not declared in this scope
   back_insert_iterator< vector<string> > it(*result);
   ^
c_helpers.cc:507:3: note: suggested alternative:
In file included from /usr/include/c++/5/bits/stl_algobase.h:67:0,
                 from /usr/include/c++/5/vector:60,
                 from c_helpers.cc:63:
/usr/include/c++/5/bits/stl_iterator.h:415:11: note:   'std::back_insert_iterator'
     class back_insert_iterator
           ^
c_helpers.cc:507:40: error: expected primary-expression before '>' token
   back_insert_iterator< vector<string> > it(*result);
                                        ^
c_helpers.cc:507:52: error: 'it' was not declared in this scope
   back_insert_iterator< vector<string> > it(*result);