### PR TITLE
Bump minimum required header version for proto3 syntax

### DIFF
--- a/protoc-c/c_file.cc
+++ b/protoc-c/c_file.cc
@@ -119,7 +119,10 @@ FileGenerator::~FileGenerator() {}
 void FileGenerator::GenerateHeader(io::Printer* printer) {
   string filename_identifier = FilenameIdentifier(file_->name());
 
-  static const int min_header_version = 1000000;
+  int min_header_version = 1000000;
+  if (file_->syntax() == FileDescriptor::SYNTAX_PROTO3) {
+    min_header_version = 1003000;
+  }
 
   // Generate top of header.
   printer->Print(


### PR DESCRIPTION
The changes in #274 (proto3: make strings default to "" instead of NULL) add a new symbol to the library and add an `extern` declaration to the protobuf-c header file.

Since the compiler may generate files that depend on that new `protobuf_c_empty_string` declaration in protobuf-c.h, we need to bump the `min_header_version` value that is written into generated header files. But since the `protobuf_c_empty_string` symbol can only be referenced when generating proto3 syntax files, we only need to use the stricter `min_header_version` value when processing a proto3 file.