### PR TITLE
Restore protobuf-2.x compatibility

### DIFF
--- a/protoc-c/c_file.cc
+++ b/protoc-c/c_file.cc
@@ -120,9 +120,11 @@ void FileGenerator::GenerateHeader(io::Printer* printer) {
   string filename_identifier = FilenameIdentifier(file_->name());
 
   int min_header_version = 1000000;
+#if defined(HAVE_PROTO3)
   if (file_->syntax() == FileDescriptor::SYNTAX_PROTO3) {
     min_header_version = 1003000;
   }
+#endif
 
   // Generate top of header.
   printer->Print(


### PR DESCRIPTION
The change in commit 712154b912de824741381c0bb26c2fbed54515a3 ("Bump minimum required header version for proto3 syntax") uses functionality only exposed by protobuf-3.x, breaking the build when compiling against protobuf-2.x.

Since we still want to support building against protobuf-2.x, this commit makes the proto3 syntax check in the file generator dependent on building against protobuf-3.x.