### PR TITLE
Add new public functions for applications which use protobuf-c

### DIFF
--- a/protobuf-c/libprotobuf-c.sym
+++ b/protobuf-c/libprotobuf-c.sym
@@ -26,4 +26,5 @@ LIBPROTOBUF_C_1.3.0 {
 global:
         protobuf_c_empty_string;
         protobuf_c_message_free_unknown_fields;
+        protobuf_c_service_descriptor_get_method_index_by_name;
 } LIBPROTOBUF_C_1.0.0;

--- a/protobuf-c/libprotobuf-c.sym
+++ b/protobuf-c/libprotobuf-c.sym
@@ -25,4 +25,5 @@ local:
 LIBPROTOBUF_C_1.3.0 {
 global:
         protobuf_c_empty_string;
+        protobuf_c_message_free_unknown_fields;
 } LIBPROTOBUF_C_1.0.0;

--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -3622,36 +3622,48 @@ protobuf_c_message_descriptor_get_field(const ProtobufCMessageDescriptor *desc,
 	return desc->fields + rv;
 }
 
+unsigned
+protobuf_c_service_descriptor_get_method_index_by_name(const ProtobufCServiceDescriptor *desc,
+						 const char *name)
+{
+	unsigned start = 0;
+ 	unsigned count;
+
+ 	if (desc == NULL || desc->method_indices_by_name == NULL)
+		return UNDEFINED_METHOD;
+ 
+ 	count = desc->n_methods;
+ 
+ 	while (count > 1) {
+ 		unsigned mid = start + count / 2;
+ 		unsigned mid_index = desc->method_indices_by_name[mid];
+ 		const char *mid_name = desc->methods[mid_index].name;
+ 		int rv = strcmp(mid_name, name);
+ 
+ 		if (rv == 0)
+			return desc->method_indices_by_name[mid];
+ 		if (rv < 0) {
+ 			count = start + count - (mid + 1);
+ 			start = mid + 1;
+ 		} else {
+ 			count = mid - start;
+ 		}
+ 	}
+ 	if (count == 0)
+		return UNDEFINED_METHOD;
+ 	if (strcmp(desc->methods[desc->method_indices_by_name[start]].name, name) == 0)
+		return desc->method_indices_by_name[start];
+	return UNDEFINED_METHOD;
+}
+
 const ProtobufCMethodDescriptor *
 protobuf_c_service_descriptor_get_method_by_name(const ProtobufCServiceDescriptor *desc,
 						 const char *name)
 {
-	unsigned start = 0;
-	unsigned count;
+	unsigned index = protobuf_c_service_descriptor_get_method_index_by_name(desc, name);
 
-	if (desc == NULL || desc->method_indices_by_name == NULL)
-		return NULL;
+	if (index != UNDEFINED_METHOD)
+		return desc->methods + desc->method_indices_by_name[index];
 
-	count = desc->n_methods;
-
-	while (count > 1) {
-		unsigned mid = start + count / 2;
-		unsigned mid_index = desc->method_indices_by_name[mid];
-		const char *mid_name = desc->methods[mid_index].name;
-		int rv = strcmp(mid_name, name);
-
-		if (rv == 0)
-			return desc->methods + desc->method_indices_by_name[mid];
-		if (rv < 0) {
-			count = start + count - (mid + 1);
-			start = mid + 1;
-		} else {
-			count = mid - start;
-		}
-	}
-	if (count == 0)
-		return NULL;
-	if (strcmp(desc->methods[desc->method_indices_by_name[start]].name, name) == 0)
-		return desc->methods + desc->method_indices_by_name[start];
 	return NULL;
 }

--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -3298,6 +3298,25 @@ error_cleanup_during_scan:
 }
 
 void
+protobuf_c_message_free_unknown_fields (ProtobufCMessage *message,
+					 ProtobufCAllocator *allocator)
+{
+	unsigned f;
+
+	if (message == NULL)
+		return;
+
+	for (f = 0; f < message->n_unknown_fields; f++)
+		do_free (allocator, message->unknown_fields[f].data);
+
+	if (message->unknown_fields != NULL)
+		do_free (allocator, message->unknown_fields);
+
+	message->n_unknown_fields = 0;
+	message->unknown_fields = NULL;
+}
+
+void
 protobuf_c_message_free_unpacked(ProtobufCMessage *message,
 				 ProtobufCAllocator *allocator)
 {
@@ -3378,11 +3397,7 @@ protobuf_c_message_free_unpacked(ProtobufCMessage *message,
 		}
 	}
 
-	for (f = 0; f < message->n_unknown_fields; f++)
-		do_free(allocator, message->unknown_fields[f].data);
-	if (message->unknown_fields != NULL)
-		do_free(allocator, message->unknown_fields);
-
+	protobuf_c_message_free_unknown_fields (message, allocator);
 	do_free(allocator, message);
 }
 

--- a/protobuf-c/protobuf-c.h
+++ b/protobuf-c/protobuf-c.h
@@ -237,6 +237,8 @@ PROTOBUF_C__BEGIN_DECLS
 #define PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC    0x28aaeef9
 #define PROTOBUF_C__ENUM_DESCRIPTOR_MAGIC       0x114315af
 
+#define UNDEFINED_METHOD 0xffffffff
+
 /* Empty string used for initializers */
 extern const char protobuf_c_empty_string[];
 
@@ -1103,6 +1105,12 @@ PROTOBUF_C__API
 void protobuf_c_message_free_unknown_fields (
 	ProtobufCMessage *message,
 	ProtobufCAllocator *allocator);
+
+PROTOBUF_C__API
+unsigned
+protobuf_c_service_descriptor_get_method_index_by_name(
+	const ProtobufCServiceDescriptor *desc,
+	const char *name);
 
 /**@}*/
 

--- a/protobuf-c/protobuf-c.h
+++ b/protobuf-c/protobuf-c.h
@@ -1099,6 +1099,11 @@ protobuf_c_service_invoke_internal(
 	ProtobufCClosure closure,
 	void *closure_data);
 
+PROTOBUF_C__API
+void protobuf_c_message_free_unknown_fields (
+	ProtobufCMessage *message,
+	ProtobufCAllocator *allocator);
+
 /**@}*/
 
 PROTOBUF_C__END_DECLS


### PR DESCRIPTION
This pull request adds two new functions which are useful for an existing application which uses protobuf-c. Specifically:

- protobuf_c_message_free_unknown_fields
- protobuf_c_service_descriptor_get_method_index_by_name