### PR TITLE
VS2008 support

### DIFF
--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -175,11 +175,19 @@ do_free(ProtobufCAllocator *allocator, void *data)
  * allocator used if NULL is passed as the ProtobufCAllocator to an exported
  * function.
  */
+#ifndef _MSC_VER
+#define STRUCT_FIELD(name, value) .name = value
+#else
+#define STRUCT_FIELD(name, value) value
+#endif
+ 
 static ProtobufCAllocator protobuf_c__allocator = {
-	.alloc = &system_alloc,
-	.free = &system_free,
-	.allocator_data = NULL,
+	STRUCT_FIELD(alloc, &system_alloc),
+	STRUCT_FIELD(free, &system_free),
+	STRUCT_FIELD(allocator_data, NULL),
 };
+
+#undef STRUCT_FIELD
 
 /* === buffer-simple === */
 

--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -175,20 +175,10 @@ do_free(ProtobufCAllocator *allocator, void *data)
  * allocator used if NULL is passed as the ProtobufCAllocator to an exported
  * function.
  */
-#ifndef _MSC_VER
-#define STRUCT_FIELD(name, value) .name = value
-#else
-#define STRUCT_FIELD(name, value) value
-#endif
  
-static ProtobufCAllocator protobuf_c__allocator = {
-	STRUCT_FIELD(alloc, &system_alloc),
-	STRUCT_FIELD(free, &system_free),
-	STRUCT_FIELD(allocator_data, NULL),
-};
-
-#undef STRUCT_FIELD
-
+static ProtobufCAllocator protobuf_c__allocator = \
+    ProtobufCAllocator_INIT(&system_alloc, &system_free, NULL);
+ 
 /* === buffer-simple === */
 
 void

--- a/protobuf-c/protobuf-c.h
+++ b/protobuf-c/protobuf-c.h
@@ -227,6 +227,12 @@ typedef __int64 int64_t;
 #include <stdint.h>
 #endif
 
+#ifndef _MSC_VER
+#define NAMED_STRUCT_FIELD(name, value) .name = value
+#else
+#define NAMED_STRUCT_FIELD(name, value) value
+#endif
+
 #ifdef __cplusplus
 # define PROTOBUF_C__BEGIN_DECLS	extern "C" {
 # define PROTOBUF_C__END_DECLS		}
@@ -380,6 +386,13 @@ struct ProtobufCMessageUnknownField;
 struct ProtobufCMethodDescriptor;
 struct ProtobufCService;
 struct ProtobufCServiceDescriptor;
+
+#define ProtobufCAllocator_INIT(alloc_val, free_val, allocator_data_val) \
+    {                                                           \
+        NAMED_STRUCT_FIELD(alloc, alloc_val),                   \
+        NAMED_STRUCT_FIELD(free, free_val),                     \
+        NAMED_STRUCT_FIELD(allocator_data, allocator_data_val), \
+    }
 
 typedef struct ProtobufCAllocator ProtobufCAllocator;
 typedef struct ProtobufCBinaryData ProtobufCBinaryData;

--- a/protobuf-c/protobuf-c.h
+++ b/protobuf-c/protobuf-c.h
@@ -200,7 +200,7 @@ size_t foo__bar__baz_bah__pack_to_buffer
 #include <limits.h>
 #include <stddef.h>
 
-#if _MSC_VER <= 1600
+#if defined(_MSC_VER) && _MSC_VER <= 1600
 // define used stuff from stdint manually
 typedef unsigned __int8 uint8_t;
 typedef __int8 int8_t;

--- a/protobuf-c/protobuf-c.h
+++ b/protobuf-c/protobuf-c.h
@@ -199,7 +199,33 @@ size_t foo__bar__baz_bah__pack_to_buffer
 #include <assert.h>
 #include <limits.h>
 #include <stddef.h>
+
+#if _MSC_VER <= 1600
+// define used stuff from stdint manually
+typedef unsigned __int8 uint8_t;
+typedef __int8 int8_t;
+typedef unsigned __int16 uint16_t;
+typedef __int16 int16_t;
+typedef unsigned __int32 uint32_t;
+typedef __int32 int32_t;
+typedef unsigned __int64 uint64_t;
+typedef __int64 int64_t;
+
+#define INT8_MIN     ((int8_t)_I8_MIN)
+#define INT8_MAX     _I8_MAX
+#define INT16_MIN    ((int16_t)_I16_MIN)
+#define INT16_MAX    _I16_MAX
+#define INT32_MIN    ((int32_t)_I32_MIN)
+#define INT32_MAX    _I32_MAX
+#define INT64_MIN    ((int64_t)_I64_MIN)
+#define INT64_MAX    _I64_MAX
+#define UINT8_MAX    _UI8_MAX
+#define UINT16_MAX   _UI16_MAX
+#define UINT32_MAX   _UI32_MAX
+#define UINT64_MAX   _UI64_MAX
+#else
 #include <stdint.h>
+#endif
 
 #ifdef __cplusplus
 # define PROTOBUF_C__BEGIN_DECLS	extern "C" {


### PR DESCRIPTION
Made protobuf-c compilable using VS2008.

Yes, I know it's ancient... but I wanted to use this project in another project for making a Python2 extension, and Python2 is built using VS2008 for historical reasons... should not hurt anyone to make it possible to build with old compilers, IMHO.