### PR TITLE
Check if tag is equal to 0

### DIFF
--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -2072,6 +2072,11 @@ parse_tag_and_wiretype(size_t len,
 	unsigned shift = 4;
 	unsigned rv;
 
+	/* 0 is not a valid tag value */
+	if ((data[0] & 0xf8) == 0) {
+		return 0;
+	}
+
 	*wiretype_out = data[0] & 7;
 	if ((data[0] & 0x80) == 0) {
 		*tag_out = tag;


### PR DESCRIPTION
This is needed because in the syntax of Google protobuf the zero
value is not valid tag value. The specification
(https://developers.google.com/protocol-buffers/docs/proto3) says
that "The smallest tag number you can specify is 1, and the largest
is 2^29-1, or 536,870,911."