### PR TITLE
Cleaned a [-Wmaybe-uninitialized] warning in protobuf-c.c

### DIFF
--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -2119,12 +2119,12 @@ scan_length_prefixed_data(size_t len, const uint8_t *data,
 		if ((data[i] & 0x80) == 0)
 			break;
 	}
+	hdr_len = i + 1;
+	*prefix_len_out = hdr_len;
 	if (i == hdr_max) {
 		PROTOBUF_C_UNPACK_ERROR("error parsing length for length-prefixed data");
 		return 0;
 	}
-	hdr_len = i + 1;
-	*prefix_len_out = hdr_len;
 	if (hdr_len + val > len) {
 		PROTOBUF_C_UNPACK_ERROR("data too short after length-prefix of %u", val);
 		return 0;


### PR DESCRIPTION
The warning (from avr-gcc 7.3.0) was:

    protobuf-c.c: In function 'protobuf_c_message_unpack':
    protobuf-c.c:3147:26: warning: 'pref_len' may be used uninitialized in this function [-Wmaybe-uninitialized]

It's nothing super important, but I like my builds squeaky clean when I can manage it.
