### PR TITLE
Update Travis to use xenial, protobuf 3.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 
 env:
   global:
-    - PROTOBUF_VERSION=3.0.2
+    - PROTOBUF_VERSION=3.6.1
     - PKG_CONFIG_PATH=$HOME/protobuf-$PROTOBUF_VERSION-bin/lib/pkgconfig
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
 
 env:
   global:
+    - CXX="g++ -std=c++11"
     - PROTOBUF_VERSION=3.6.1
     - PKG_CONFIG_PATH=$HOME/protobuf-$PROTOBUF_VERSION-bin/lib/pkgconfig
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,45 +2,19 @@ language:
     - c
     - cpp
 
-# Use Trusty VM
 sudo: required
-dist: trusty
+dist: xenial
 
-matrix:
-  include:
-    # Test default gcc
-    - env: GCC_VERSION=4.8
-      os: linux
-      compiler: gcc
-      addons:
-        apt:
-          packages:
-            - lcov
-            - valgrind
+addons:
+  apt:
+    packages:
+      - lcov
+      - valgrind
 
-    # Test gcc-5.0
-    - env: GCC_VERSION=5
-      os: linux
-      addons:
-        apt:
-          packages:
-            - valgrind
-            - g++-5
-            - gcc-5
-          sources:
-            - ubuntu-toolchain-r-test
 env:
-    global:
-        - PROTOBUF_VERSION=3.0.2
-        - PKG_CONFIG_PATH=$HOME/protobuf-$PROTOBUF_VERSION-bin/lib/pkgconfig
-
-before_install:
-    - if [ -n "$GCC_VERSION" ]; then export CXX="g++-${GCC_VERSION}" CC="gcc-${GCC_VERSION}"; fi
-    - if [ -n "$CLANG_VERSION" ]; then export CXX="clang++-${CLANG_VERSION}" CC="clang-${CLANG_VERSION}"; fi
-    - if [ "$GCC_VERSION" == "4.8" ]; then export CXX="g++" CC="gcc"; fi
-    - which $CXX
-    - which $CC
-    - which valgrind
+  global:
+    - PROTOBUF_VERSION=3.0.2
+    - PKG_CONFIG_PATH=$HOME/protobuf-$PROTOBUF_VERSION-bin/lib/pkgconfig
 
 install:
     - pip install --user cpp-coveralls
@@ -51,8 +25,7 @@ install:
 script:
     - ./autogen.sh
     - ./configure && make -j2 distcheck VERBOSE=1 && make clean
-    - if [ "$GCC_VERSION" != "4.8" ]; then ./configure --enable-valgrind-tests CFLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined" && make -j2 distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-valgrind-tests CFLAGS=\"-fsanitize=undefined -fno-sanitize-recover=undefined\"" VERBOSE=1 && make clean; fi
-    - if [ "$CC" = "gcc" ]; then ./configure --enable-code-coverage && make -j2 && make check; fi
+    - ./configure --enable-valgrind-tests CFLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined" && make -j2 distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-valgrind-tests CFLAGS=\"-fsanitize=undefined -fno-sanitize-recover=undefined\"" VERBOSE=1 && make clean
 
 after_success:
-    - if [ "$CC" = "gcc" ]; then cpp-coveralls --build-root . --exclude t/ --exclude /usr/include --exclude protobuf-$PROTOBUF_VERSION --exclude protoc-c; fi
+    - cpp-coveralls --build-root . --exclude t/ --exclude /usr/include --exclude protobuf-$PROTOBUF_VERSION --exclude protoc-c


### PR DESCRIPTION
This branch updates Travis to use the xenial base image rather than trusty, and installs the latest protobuf 3.6.1 release. Note that we need to set the environment variable `CXX="g++ -std=c++11"` due to xenial using an older g++ version.

The CI build is not currently successful because we also need some additional fixes due to changes in protobuf.