### PR TITLE
Convert uses of protobuf's scoped_ptr.h to C++11 std::unique_ptr

### DIFF
--- a/protoc-c/c_field.cc
+++ b/protoc-c/c_field.cc
@@ -189,7 +189,7 @@ void FieldGenerator::GenerateDescriptorInitializerGeneric(io::Printer* printer,
 FieldGeneratorMap::FieldGeneratorMap(const Descriptor* descriptor)
   : descriptor_(descriptor),
     field_generators_(
-      new scoped_ptr<FieldGenerator>[descriptor->field_count()]) {
+      new std::unique_ptr<FieldGenerator>[descriptor->field_count()]) {
   // Construct all the FieldGenerators.
   for (int i = 0; i < descriptor->field_count(); i++) {
     field_generators_[i].reset(MakeGenerator(descriptor->field(i)));

--- a/protoc-c/c_field.h
+++ b/protoc-c/c_field.h
@@ -63,6 +63,7 @@
 #ifndef GOOGLE_PROTOBUF_COMPILER_C_FIELD_H__
 #define GOOGLE_PROTOBUF_COMPILER_C_FIELD_H__
 
+#include <memory>
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/descriptor.h>
 
@@ -117,7 +118,7 @@ class FieldGeneratorMap {
 
  private:
   const Descriptor* descriptor_;
-  scoped_array<scoped_ptr<FieldGenerator> > field_generators_;
+  std::unique_ptr<std::unique_ptr<FieldGenerator>[]> field_generators_;
 
   static FieldGenerator* MakeGenerator(const FieldDescriptor* field);
 

--- a/protoc-c/c_file.cc
+++ b/protoc-c/c_file.cc
@@ -83,13 +83,13 @@ FileGenerator::FileGenerator(const FileDescriptor* file,
                              const string& dllexport_decl)
   : file_(file),
     message_generators_(
-      new scoped_ptr<MessageGenerator>[file->message_type_count()]),
+      new std::unique_ptr<MessageGenerator>[file->message_type_count()]),
     enum_generators_(
-      new scoped_ptr<EnumGenerator>[file->enum_type_count()]),
+      new std::unique_ptr<EnumGenerator>[file->enum_type_count()]),
     service_generators_(
-      new scoped_ptr<ServiceGenerator>[file->service_count()]),
+      new std::unique_ptr<ServiceGenerator>[file->service_count()]),
     extension_generators_(
-      new scoped_ptr<ExtensionGenerator>[file->extension_count()]) {
+      new std::unique_ptr<ExtensionGenerator>[file->extension_count()]) {
 
   for (int i = 0; i < file->message_type_count(); i++) {
     message_generators_[i].reset(

--- a/protoc-c/c_file.h
+++ b/protoc-c/c_file.h
@@ -63,6 +63,7 @@
 #ifndef GOOGLE_PROTOBUF_COMPILER_C_FILE_H__
 #define GOOGLE_PROTOBUF_COMPILER_C_FILE_H__
 
+#include <memory>
 #include <string>
 #include <vector>
 #include <google/protobuf/stubs/common.h>
@@ -98,10 +99,10 @@ class FileGenerator {
  private:
   const FileDescriptor* file_;
 
-  scoped_array<scoped_ptr<MessageGenerator> > message_generators_;
-  scoped_array<scoped_ptr<EnumGenerator> > enum_generators_;
-  scoped_array<scoped_ptr<ServiceGenerator> > service_generators_;
-  scoped_array<scoped_ptr<ExtensionGenerator> > extension_generators_;
+  std::unique_ptr<std::unique_ptr<MessageGenerator>[]> message_generators_;
+  std::unique_ptr<std::unique_ptr<EnumGenerator>[]> enum_generators_;
+  std::unique_ptr<std::unique_ptr<ServiceGenerator>[]> service_generators_;
+  std::unique_ptr<std::unique_ptr<ExtensionGenerator>[]> extension_generators_;
 
   // E.g. if the package is foo.bar, package_parts_ is {"foo", "bar"}.
   std::vector<string> package_parts_;

--- a/protoc-c/c_generator.cc
+++ b/protoc-c/c_generator.cc
@@ -62,6 +62,7 @@
 
 #include <protoc-c/c_generator.h>
 
+#include <memory>
 #include <vector>
 #include <utility>
 
@@ -149,7 +150,7 @@ bool CGenerator::Generate(const FileDescriptor* file,
 
   // Generate header.
   {
-    scoped_ptr<io::ZeroCopyOutputStream> output(
+    std::unique_ptr<io::ZeroCopyOutputStream> output(
       output_directory->Open(basename + ".h"));
     io::Printer printer(output.get(), '$');
     file_generator.GenerateHeader(&printer);
@@ -157,7 +158,7 @@ bool CGenerator::Generate(const FileDescriptor* file,
 
   // Generate cc file.
   {
-    scoped_ptr<io::ZeroCopyOutputStream> output(
+    std::unique_ptr<io::ZeroCopyOutputStream> output(
       output_directory->Open(basename + ".c"));
     io::Printer printer(output.get(), '$');
     file_generator.GenerateSource(&printer);

--- a/protoc-c/c_helpers.cc
+++ b/protoc-c/c_helpers.cc
@@ -60,6 +60,7 @@
 
 // Modified to implement C code by Dave Benson.
 
+#include <memory>
 #include <vector>
 #include <set>
 #include <stdio.h>		// for snprintf
@@ -559,7 +560,7 @@ static int CEscapeInternal(const char* src, int src_len, char* dest,
 }
 string CEscape(const string& src) {
   const int dest_length = src.size() * 4 + 1; // Maximum possible expansion
-  scoped_array<char> dest(new char[dest_length]);
+  std::unique_ptr<char[]> dest(new char[dest_length]);
   const int len = CEscapeInternal(src.data(), src.size(),
                                   dest.get(), dest_length, false);
   GOOGLE_DCHECK_GE(len, 0);

--- a/protoc-c/c_message.cc
+++ b/protoc-c/c_message.cc
@@ -62,6 +62,7 @@
 
 #include <algorithm>
 #include <map>
+#include <memory>
 #include <protoc-c/c_message.h>
 #include <protoc-c/c_enum.h>
 #include <protoc-c/c_extension.h>
@@ -83,11 +84,11 @@ MessageGenerator::MessageGenerator(const Descriptor* descriptor,
   : descriptor_(descriptor),
     dllexport_decl_(dllexport_decl),
     field_generators_(descriptor),
-    nested_generators_(new scoped_ptr<MessageGenerator>[
+    nested_generators_(new std::unique_ptr<MessageGenerator>[
       descriptor->nested_type_count()]),
-    enum_generators_(new scoped_ptr<EnumGenerator>[
+    enum_generators_(new std::unique_ptr<EnumGenerator>[
       descriptor->enum_type_count()]),
-    extension_generators_(new scoped_ptr<ExtensionGenerator>[
+    extension_generators_(new std::unique_ptr<ExtensionGenerator>[
       descriptor->extension_count()]) {
 
   for (int i = 0; i < descriptor->nested_type_count(); i++) {

--- a/protoc-c/c_message.h
+++ b/protoc-c/c_message.h
@@ -63,6 +63,7 @@
 #ifndef GOOGLE_PROTOBUF_COMPILER_C_MESSAGE_H__
 #define GOOGLE_PROTOBUF_COMPILER_C_MESSAGE_H__
 
+#include <memory>
 #include <string>
 #include <google/protobuf/stubs/common.h>
 #include <protoc-c/c_field.h>
@@ -126,9 +127,9 @@ class MessageGenerator {
   const Descriptor* descriptor_;
   string dllexport_decl_;
   FieldGeneratorMap field_generators_;
-  scoped_array<scoped_ptr<MessageGenerator> > nested_generators_;
-  scoped_array<scoped_ptr<EnumGenerator> > enum_generators_;
-  scoped_array<scoped_ptr<ExtensionGenerator> > extension_generators_;
+  std::unique_ptr<std::unique_ptr<MessageGenerator>[]> nested_generators_;
+  std::unique_ptr<std::unique_ptr<EnumGenerator>[]> enum_generators_;
+  std::unique_ptr<std::unique_ptr<ExtensionGenerator>[]> extension_generators_;
 
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(MessageGenerator);
 };


### PR DESCRIPTION
Upstream protobuf removed scoped_ptr.h, which provided the `scoped_ptr` that we depended on, in commit https://github.com/google/protobuf/commit/67952fab2c766ac5eacc15bb78e5af4039a3d398.

This commit converts uses of `scoped_ptr` type to idiomatic C++11 `std::unique_ptr`, similar to the changes in the protobuf commit.

This has been tested on protobuf 3.0.0 (the version currently in Debian) as well as the latest protobuf 3.6.1 release.