### PR TITLE
Add meson build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /aclocal.m4
 /autom4te.cache
 /build-aux
+/build/
 /config.*
 /configure
 /doxygen-doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,24 @@ dist: xenial
 addons:
   apt:
     packages:
+      - python3
+      - python3-pip
+      - python3-setuptools
+      - python3-wheel
+      - ninja-build
       - valgrind
 
 env:
   global:
     - PROTOBUF_VERSION=3.6.1
     - PKG_CONFIG_PATH=$HOME/protobuf-$PROTOBUF_VERSION-bin/lib/pkgconfig
+    - LD_LIBRARY_PATH=$HOME/protobuf-$PROTOBUF_VERSION-bin/lib
 
 install:
+    - pip3 install meson
     - wget https://github.com/google/protobuf/archive/v$PROTOBUF_VERSION.tar.gz
     - tar xf v$PROTOBUF_VERSION.tar.gz
     - ( cd protobuf-$PROTOBUF_VERSION && ./autogen.sh && ./configure --prefix=$HOME/protobuf-$PROTOBUF_VERSION-bin && make -j2 && make install )
 
 script:
-    - ./autogen.sh
-    - ./configure && make -j2 distcheck VERBOSE=1 && make clean
-    - ./configure --enable-valgrind-tests CFLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined" && make -j2 distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-valgrind-tests CFLAGS=\"-fsanitize=undefined -fno-sanitize-recover=undefined\"" VERBOSE=1 && make clean
+    - meson build && ninja -v -C build && meson test -C build && meson test -C build --setup=valgrind

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ dist: xenial
 addons:
   apt:
     packages:
-      - lcov
       - valgrind
 
 env:
@@ -17,7 +16,6 @@ env:
     - PKG_CONFIG_PATH=$HOME/protobuf-$PROTOBUF_VERSION-bin/lib/pkgconfig
 
 install:
-    - pip install --user cpp-coveralls
     - wget https://github.com/google/protobuf/archive/v$PROTOBUF_VERSION.tar.gz
     - tar xf v$PROTOBUF_VERSION.tar.gz
     - ( cd protobuf-$PROTOBUF_VERSION && ./autogen.sh && ./configure --prefix=$HOME/protobuf-$PROTOBUF_VERSION-bin && make -j2 && make install )
@@ -26,6 +24,3 @@ script:
     - ./autogen.sh
     - ./configure && make -j2 distcheck VERBOSE=1 && make clean
     - ./configure --enable-valgrind-tests CFLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined" && make -j2 distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-valgrind-tests CFLAGS=\"-fsanitize=undefined -fno-sanitize-recover=undefined\"" VERBOSE=1 && make clean
-
-after_success:
-    - cpp-coveralls --build-root . --exclude t/ --exclude /usr/include --exclude protobuf-$PROTOBUF_VERSION --exclude protoc-c

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,6 @@ EXTRA_DIST += README.md
 
 AM_CPPFLAGS = \
 	-include $(top_builddir)/config.h \
-	-I${top_srcdir}/protobuf-c \
 	-I${top_builddir} \
 	-I${top_srcdir}
 AM_CFLAGS = ${my_CFLAGS}

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,263 @@
+project('protobuf-c',
+  ['c', 'cpp'],
+  version : '1.3.1',
+  default_options : [
+    'buildtype=debugoptimized',
+    'c_std=c99',
+    'cpp_std=c++14',
+  ],
+  meson_version : '>= 0.47.0',
+)
+
+cc = meson.get_compiler('c')
+cpp = meson.get_compiler('cpp')
+pkgconfig = import('pkgconfig')
+
+possible_cc_flags = '''
+-Wchar-subscripts
+-Wdeclaration-after-statement
+-Werror=incompatible-pointer-types
+-Werror=int-conversion
+-Wformat-security
+-Wmissing-declarations
+-Wmissing-prototypes
+-Wnested-externs
+-Wnull-dereference
+-Wpointer-arith
+-Wshadow
+-Wsign-compare
+-Wstrict-prototypes
+-Wtype-limits
+'''.split()
+add_project_arguments(cc.get_supported_arguments(possible_cc_flags), language : 'c')
+
+#
+##
+### dependencies
+##
+#
+
+if get_option('build-compiler')
+  protobuf = dependency('protobuf',
+    version : '>= 2.6.0',
+    required : true,
+    native : true)
+
+  libprotoc = cpp.find_library('protoc',
+    required : true,
+    dirs : protobuf.get_pkgconfig_variable('libdir'))
+endif
+
+#
+##
+### config.h
+##
+#
+
+conf = configuration_data()
+
+conf.set_quoted('PACKAGE_STRING',   meson.project_name() + ' ' + meson.project_version())
+conf.set_quoted('PACKAGE_VERSION',  meson.project_version())
+
+conf.set('WORDS_BIGENDIAN', host_machine.endian() == 'big')
+conf.set('HAVE_PROTO3', protobuf.version().version_compare('>= 3.0.0'))
+
+configure_file(output : 'config.h', configuration : conf)
+
+add_project_arguments('-include', 'config.h', language : ['c', 'cpp'])
+
+#
+##
+### libprotobuf-c
+##
+#
+
+libprotobuf_c_sym = 'protobuf-c/libprotobuf-c.sym'
+libprotobuf_c_sym_path = join_paths(meson.current_source_dir(), libprotobuf_c_sym)
+
+libprotobuf_c = both_libraries('protobuf-c',
+  'protobuf-c/protobuf-c.c',
+  link_args : ['-Wl,--version-script=' + libprotobuf_c_sym_path],
+  link_depends : libprotobuf_c_sym,
+  soversion : '1',
+  version : '1.0.0',
+  install : true,
+)
+
+pkgconfig.generate(
+  name : 'libprotobuf-c',
+  description : 'Protocol Buffers C library',
+  version : meson.project_version(),
+  libraries : libprotobuf_c.get_shared_lib(),
+)
+
+install_headers('protobuf-c/protobuf-c.h', subdir : 'protobuf-c')
+
+# Support the older include path <google/protobuf-c/protobuf-c.h>
+if build_machine.system() != 'windows'
+  google_includedir = join_paths('${MESON_INSTALL_DESTDIR_PREFIX}', get_option('includedir'), 'google', 'protobuf-c')
+  google_protobuf_c_header = join_paths(google_includedir, 'protobuf-c.h')
+  meson.add_install_script('sh', '-x', '-c', 'mkdir -p ' + google_includedir)
+  meson.add_install_script('sh', '-x', '-c', 'ln -sf ../../protobuf-c/protobuf-c.h ' + google_protobuf_c_header)
+endif
+
+#
+##
+### protoc-c
+##
+#
+
+if get_option('build-compiler')
+  protoc_gen_c_sources = files('''
+    protoc-c/c_bytes_field.cc
+    protoc-c/c_bytes_field.h
+    protoc-c/c_enum.cc
+    protoc-c/c_enum.h
+    protoc-c/c_enum_field.cc
+    protoc-c/c_enum_field.h
+    protoc-c/c_extension.cc
+    protoc-c/c_extension.h
+    protoc-c/c_field.cc
+    protoc-c/c_field.h
+    protoc-c/c_file.cc
+    protoc-c/c_file.h
+    protoc-c/c_generator.cc
+    protoc-c/c_generator.h
+    protoc-c/c_helpers.cc
+    protoc-c/c_helpers.h
+    protoc-c/c_message.cc
+    protoc-c/c_message.h
+    protoc-c/c_message_field.cc
+    protoc-c/c_message_field.h
+    protoc-c/c_primitive_field.cc
+    protoc-c/c_primitive_field.h
+    protoc-c/c_service.cc
+    protoc-c/c_service.h
+    protoc-c/c_string_field.cc
+    protoc-c/c_string_field.h
+    protoc-c/main.cc
+  '''.split())
+
+  protoc_c = executable('protoc-c',
+    protoc_gen_c_sources,
+    dependencies : [protobuf, libprotoc],
+    install : true,
+    native : true,
+  )
+
+  # Create protoc-gen-c as a symlink to protoc-c
+  if build_machine.system() != 'windows'
+    install_protoc_gen_c = join_paths('${MESON_INSTALL_DESTDIR_PREFIX}', get_option('bindir'), 'protoc-gen-c')
+    meson.add_install_script('sh', '-x', '-c', 'ln -sf protoc-c ' + install_protoc_gen_c)
+  endif
+endif
+
+#
+##
+### tests
+##
+#
+
+if get_option('build-compiler') and get_option('run-tests')
+  abs_protoc_path = join_paths(protobuf.get_pkgconfig_variable('exec_prefix'), 'bin', 'protoc')
+
+  protoc = find_program([abs_protoc_path, 'protoc'],
+    required : true,
+    native : true)
+
+  gen_protobuf = generator(protoc,
+    output    : ['@BASENAME@.pb.cc', '@BASENAME@.pb.h'],
+    arguments : ['--proto_path=@CURRENT_SOURCE_DIR@', '--cpp_out=@BUILD_DIR@', '@INPUT@'])
+
+  gen_protobuf_c = generator(protoc_c,
+    output    : ['@BASENAME@.pb-c.c', '@BASENAME@.pb-c.h'],
+    arguments : ['--proto_path=@CURRENT_SOURCE_DIR@', '--c_out=@BUILD_DIR@', '@INPUT@'])
+
+  test('version', executable('t_version', 't/version/version.c', link_with : libprotobuf_c))
+
+  test('issue220',
+    executable('t_issue220', 't/issue220/issue220.c',
+      gen_protobuf_c.process('t/issue220/issue220.proto',
+        preserve_path_from : meson.current_source_dir()),
+      link_with : libprotobuf_c))
+
+  test('issue251',
+    executable('t_issue251', 't/issue251/issue251.c',
+      gen_protobuf_c.process('t/issue251/issue251.proto',
+        preserve_path_from : meson.current_source_dir()),
+      link_with : libprotobuf_c))
+
+  test('generated-code',
+    executable('t_test-generated-code', 't/generated-code/test-generated-code.c',
+      gen_protobuf_c.process('t/test.proto',
+        preserve_path_from : meson.current_source_dir()),
+      link_with : libprotobuf_c))
+
+  gen_cxx_data = custom_target('cxx-generate-packed-data',
+    output : ['test-full-cxx-output.inc'],
+    command :
+      executable('cxx-generate-packed-data', 't/generated-code2/cxx-generate-packed-data.cc',
+        gen_protobuf.process('t/test-full.proto',
+          preserve_path_from : meson.current_source_dir()),
+        dependencies : protobuf),
+    capture : true)
+
+  test('generated-code2',
+    executable('t_test-generated-code2', 't/generated-code2/test-generated-code2.c', gen_cxx_data,
+      gen_protobuf_c.process('t/test-full.proto', 't/test-optimized.proto',
+        preserve_path_from : meson.current_source_dir()),
+      link_with : libprotobuf_c))
+
+  if protobuf.version().version_compare('>= 3.0.0')
+    test('generated-code3',
+      executable('t_test-generated-code3', 't/generated-code/test-generated-code.c',
+        gen_protobuf_c.process('t/test-proto3.proto',
+          preserve_path_from : meson.current_source_dir()),
+        c_args : ['-DPROTO3'],
+        link_with : libprotobuf_c))
+  endif
+endif
+
+#
+##
+### doxygen documentation
+##
+#
+
+if get_option('build-docs')
+  doxygen = find_program('doxygen', required : false)
+  if doxygen.found()
+    cdoxy = configuration_data()
+    cdoxy.set('PACKAGE',              'protobuf-c')
+    cdoxy.set('PACKAGE_DESCRIPTION',  'Protocol Buffers implementation in C')
+    cdoxy.set('PACKAGE_VERSION',      meson.project_version())
+    cdoxy.set('top_srcdir',           meson.source_root())
+    cdoxy.set('DOXYGEN_INPUT',        join_paths(meson.source_root(), 'protobuf-c'))
+
+    doxyfile = configure_file(
+      input : 'Doxyfile.in',
+      output : 'Doxyfile',
+      configuration : cdoxy,
+      install : false)
+
+    doxygen_datadir = join_paths(get_option('datadir'), 'doc', 'protobuf-c')
+
+    html_target = custom_target('html',
+      input : doxyfile,
+      output : 'html',
+      command : [doxygen, doxyfile],
+      install : true,
+      install_dir : doxygen_datadir)
+  endif
+endif
+
+#
+##
+### valgrind test setup
+##
+#
+
+valgrind = find_program('valgrind', required : false)
+if valgrind.found()
+  add_test_setup('valgrind', exe_wrapper : [valgrind, '--quiet', '--error-exitcode=1', '--leak-check=full'])
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,3 @@
+option('build-compiler', type : 'boolean', description : 'Build protoc-gen-c / protoc_c (required by tests)')
+option('build-docs', type : 'boolean', value : false, description : 'Build Doxygen documentation')
+option('run-tests', type : 'boolean', description : 'Run test suite')

--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -2629,16 +2629,19 @@ parse_oneof_member (ScannedMember *scanned_member,
 
 	/* If we have already parsed a member of this oneof, free it. */
 	if (*oneof_case != 0) {
+		const ProtobufCFieldDescriptor *old_field;
+		int field_index;
+		size_t el_size;
+
 		/* lookup field */
-		int field_index =
+		field_index =
 			int_range_lookup(message->descriptor->n_field_ranges,
 					 message->descriptor->field_ranges,
 					 *oneof_case);
 		if (field_index < 0)
 			return FALSE;
-		const ProtobufCFieldDescriptor *old_field =
-			message->descriptor->fields + field_index;
-		size_t el_size = sizeof_elt_in_repeated_array(old_field->type);
+		old_field = message->descriptor->fields + field_index;
+		el_size = sizeof_elt_in_repeated_array(old_field->type);
 
 		switch (old_field->type) {
 	        case PROTOBUF_C_TYPE_STRING: {

--- a/protoc-c/c_file.cc
+++ b/protoc-c/c_file.cc
@@ -70,7 +70,7 @@
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/descriptor.pb.h>
 
-#include "protobuf-c.h"
+#include "protobuf-c/protobuf-c.h"
 
 namespace google {
 namespace protobuf {

--- a/protoc-c/c_helpers.cc
+++ b/protoc-c/c_helpers.cc
@@ -218,7 +218,7 @@ void PrintComment (io::Printer* printer, string comment)
       std::vector<string> comment_lines;
       SplitStringUsing (comment, "\r\n", &comment_lines);
       printer->Print ("/*\n");
-      for (int i = 0; i < comment_lines.size(); i++)
+      for (size_t i = 0; i < comment_lines.size(); i++)
       {
          if (!comment_lines[i].empty())
          {
@@ -270,7 +270,7 @@ const char* const kKeywordList[] = {
 
 std::set<string> MakeKeywordsMap() {
   std::set<string> result;
-  for (int i = 0; i < GOOGLE_ARRAYSIZE(kKeywordList); i++) {
+  for (size_t i = 0; i < GOOGLE_ARRAYSIZE(kKeywordList); i++) {
     result.insert(kKeywordList[i]);
   }
   return result;

--- a/protoc-c/main.cc
+++ b/protoc-c/main.cc
@@ -9,9 +9,9 @@ int main(int argc, char* argv[]) {
 
   std::string invocation_name = argv[0];
   std::string invocation_basename = invocation_name.substr(invocation_name.find_last_of("/") + 1);
-  const std::string legacy_name = "protoc-c";
+  const std::string standalone_name = "protoc-c";
 
-  if (invocation_basename == legacy_name) {
+  if (invocation_basename == standalone_name) {
     google::protobuf::compiler::CommandLineInterface cli;
     cli.RegisterGenerator("--c_out", &c_generator, "Generate C/H files.");
     cli.SetVersionInfo(PACKAGE_STRING);

--- a/t/generated-code2/test-generated-code2.c
+++ b/t/generated-code2/test-generated-code2.c
@@ -2327,7 +2327,7 @@ static Test tests[] =
 };
 #define n_tests (sizeof(tests)/sizeof(Test))
 
-int main ()
+int main(void)
 {
   unsigned i;
   for (i = 0; i < n_tests; i++)

--- a/t/generated-code2/test-generated-code2.c
+++ b/t/generated-code2/test-generated-code2.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include "t/test-full.pb-c.h"
 #include "t/test-optimized.pb-c.h"
-#include "t/generated-code2/test-full-cxx-output.inc"
+#include "test-full-cxx-output.inc"
 
 #define TEST_ENUM_SMALL_TYPE_NAME   Foo__TestEnumSmall
 #define TEST_ENUM_SMALL(shortname)   FOO__TEST_ENUM_SMALL__##shortname

--- a/t/version/version.c
+++ b/t/version/version.c
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "protobuf-c.h"
+#include "protobuf-c/protobuf-c.h"
 
 int
 main(int argc, char **argv)

--- a/t/version/version.c
+++ b/t/version/version.c
@@ -35,7 +35,7 @@
 #include "protobuf-c/protobuf-c.h"
 
 int
-main(int argc, char **argv)
+main(void)
 {
 	printf("PACKAGE_VERSION = %s\n",
 	       PACKAGE_VERSION);


### PR DESCRIPTION
This branch adds a meson build system to protobuf-c. I posted some details on the mesonbuild mailing list here: https://groups.google.com/forum/#!msg/mesonbuild/NOIpv8KaOjE/S6n3JrGnBAAJ.

Unfortunately, the features used in the `meson.build` file are relatively recent (meson ≥ 0.47.0 is required, which is only a two month old release). In the Travis-CI environment it seems sufficient to install the python3 and ninja-build packages that are shipped in xenial and install meson via pip3.

The meson build system in this branch is mostly equivalent to the current autotools build system. I did not bother with setting up code coverage reports, though, as I've not found the reports generated by coveralls to be all that useful, as we aren't really adding a whole lot of new code all that frequently.

The only real concession I had to make was to reverse the symlink relationship between `protoc-c` and `protoc-gen-c`. I couldn't figure out a way to express the dependencies on the code generator when `protoc-c` was a symlink to `protoc-gen-c`, so I swapped them around.

I'd like to eventually remove the autotools and CMake build systems provided that meson ends up being a sufficient replacement. (Note that this branch doesn't update the build instructions in the README.)

To build/test/install, do something like:

```
meson build
ninja -C build
ninja -C build test
DESTDIR=/tmp/inst ninja -C build install
```

If everything went correctly, you should get an installation tree like:

```
.
└── [4.0K]  usr
    └── [4.0K]  local
        ├── [4.0K]  bin
        │   ├── [6.4M]  protoc-c
        │   └── [   8]  protoc-gen-c -> protoc-c
        ├── [4.0K]  include
        │   ├── [4.0K]  google
        │   │   └── [4.0K]  protobuf-c
        │   │       └── [  29]  protobuf-c.h -> ../../protobuf-c/protobuf-c.h
        │   └── [4.0K]  protobuf-c
        │       └── [ 33K]  protobuf-c.h
        └── [4.0K]  lib
            └── [4.0K]  x86_64-linux-gnu
                ├── [278K]  libprotobuf-c.a
                ├── [  18]  libprotobuf-c.so -> libprotobuf-c.so.1
                ├── [  22]  libprotobuf-c.so.1 -> libprotobuf-c.so.1.0.0
                ├── [208K]  libprotobuf-c.so.1.0.0
                └── [4.0K]  pkgconfig
                    └── [ 216]  libprotobuf-c.pc

10 directories, 9 files
```

@pbor, @lipnitsk, do you have any interest in reviewing this?

Thanks!