### PR TITLE
Invalid namespace

### DIFF
--- a/t/generated-code2/cxx-generate-packed-data.cc
+++ b/t/generated-code2/cxx-generate-packed-data.cc
@@ -998,7 +998,7 @@ static void dump_test_packed_repeated_enum (void)
 static void dump_test_unknown_fields (void)
 {
   EmptyMess mess;
-  const google::protobuf::Message::Reflection *reflection = mess.GetReflection();
+  const google::protobuf::Reflection *reflection = mess.GetReflection();
   google::protobuf::UnknownFieldSet *fs = reflection->MutableUnknownFields(&mess);
 
 #if GOOGLE_PROTOBUF_VERSION >= 2001000


### PR DESCRIPTION
google::protobuf::message::Reflaction is not exist namespace.

I try to ubuntu build. But namespace is invalid, so can't build.

I changed correct namespace

