### PR TITLE
Fix a SEGV on on protobuf_c_message_check on messages with 'oneof's inside

### DIFF
--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -3414,6 +3414,13 @@ protobuf_c_message_check(const ProtobufCMessage *message)
 		ProtobufCType type = f->type;
 		ProtobufCLabel label = f->label;
 		void *field = STRUCT_MEMBER_P (message, f->offset);
+		
+		if (f->flags & PROTOBUF_C_FIELD_FLAG_ONEOF) {
+			const uint32_t *oneof_case = STRUCT_MEMBER_P (message, f->quantifier_offset);
+			if (f->id != *oneof_case) {
+				continue; //Do not check if it is an unpopulated oneof member.
+			}
+		}
 
 		if (label == PROTOBUF_C_LABEL_REPEATED) {
 			size_t *quantity = STRUCT_MEMBER_P (message, f->quantifier_offset);

--- a/t/generated-code2/test-generated-code2.c
+++ b/t/generated-code2/test-generated-code2.c
@@ -964,6 +964,15 @@ static void test_oneof_SubMess (void)
   DO_TEST (&submess, test_optional_submess_42);
 #undef DO_TEST
 }
+
+static void test_oneof_message_check(void)
+{
+	Foo__TestMessOneof msg = FOO__TEST_MESS_ONEOF__INIT;
+	msg.test_oneof_case = FOO__TEST_MESS_ONEOF__TEST_ONEOF_TEST_STRING;
+	msg.test_string = "Hello, world!";
+	assert(protobuf_c_message_check((ProtobufCMessage *)&msg));
+}
+
 static void test_oneof_merge (void)
 {
   Foo__TestMessOneof *msg;
@@ -2260,6 +2269,7 @@ static Test tests[] =
   { "test oneof string", test_oneof_string },
   { "test oneof bytes", test_oneof_bytes },
   { "test oneof SubMess", test_oneof_SubMess },
+  { "test oneof message check", test_oneof_message_check },
   { "test merged oneof unpack", test_oneof_merge },
 
   { "test empty repeated" ,test_empty_repeated },


### PR DESCRIPTION
The `protobuf_c_message_check` function used to dereference unpopulated 'oneof' members that are messages, while scalar members were populated. This would cause segfaults or other errors.

Example .proto file to reproduce the problem:
```
syntax = "proto2";

package testing;

message TestMessage {
	message SubMessage {
		required string sub_a = 1;
		required string sub_b = 2;
	}
	oneof Type {
		string oneof_a = 1;
		string oneof_b = 2;
		SubMessage sub = 3;
	}
}
```

example code to reproduce the crash:

```
#include "generated_code/main.idl.pb-c.h"

int main()
{
	Testing__TestMessage msg = TESTING__TEST_MESSAGE__INIT;
	msg.type_case = TESTING__TEST_MESSAGE__TYPE_ONEOF_A;
	msg.oneof_a = "Hello, world!";
	protobuf_c_message_check((ProtobufCMessage *)&msg);

	return 0;
}
```

Signed-off-by: Hayri Ugur Koltuk <ugur.koltuk@adyen.com>