### PR TITLE
Add compatibility for compilers that use 32-bit doubles

### DIFF
--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -553,7 +553,21 @@ field_is_zeroish(const ProtobufCFieldDescriptor *field,
 		ret = (0 == *(const float *) member);
 		break;
 	case PROTOBUF_C_TYPE_DOUBLE:
+#if (__DBL_MANT_DIG__ != 53 && __LDBL_MANT_DIG__ == 53)
+/*
+ * Some embedded compilers can be configured for 32-bit doubles, but a native
+ * 64-bit type is needed to support the 64-bit protobuf double type.  If the
+ * preprocessor is activating this block, the target environment falls into
+ * this category: the target environment's native double type is not 64-bit.
+ * But if __LDBL_MANT_DIG__ == 53, the target's long double type is 64-bit.
+ * Therefore, use long double to represent 64-bit protobuf doubles.
+ */
+		ret = (0 == *(const long double *) member);
+#elif (__DBL_MANT_DIG__ != 53)
+#error unable find a native 64-bit type for the protobuf double!
+#else
 		ret = (0 == *(const double *) member);
+#endif
 		break;
 	case PROTOBUF_C_TYPE_STRING:
 		ret = (NULL == *(const char * const *) member) ||

--- a/protoc-c/c_message.cc
+++ b/protoc-c/c_message.cc
@@ -443,7 +443,13 @@ GenerateMessageDescriptor(io::Printer* printer) {
 	  vars["field_dv_ctype"] = "float";
 	  break;
 	case FieldDescriptor::CPPTYPE_DOUBLE:
-	  vars["field_dv_ctype"] = "double";
+	  vars["field_dv_ctype"] = "\n#if (__DBL_MANT_DIG__ != 53 && __LDBL_MANT_DIG__ == 53)\n"
+                                   "long double /* The target environment's native double type is not 64-bit, but its long double type is; use that. */\n"
+                                   "#elif (__DBL_MANT_DIG__ != 53)\n"
+                                   "#error: unable to locate a native 64-bit floating point type to support protobuf doubles!\n"
+                                   "#else\n"
+                                   "double\n"
+                                   "#endif\n";
 	  break;
 	case FieldDescriptor::CPPTYPE_BOOL:
 	  vars["field_dv_ctype"] = "protobuf_c_boolean";

--- a/protoc-c/c_primitive_field.cc
+++ b/protoc-c/c_primitive_field.cc
@@ -93,7 +93,14 @@ void PrimitiveFieldGenerator::GenerateStructMembers(io::Printer* printer) const
     case FieldDescriptor::TYPE_UINT64  : 
     case FieldDescriptor::TYPE_FIXED64 : c_type = "uint64_t"; break;
     case FieldDescriptor::TYPE_FLOAT   : c_type = "float"; break;
-    case FieldDescriptor::TYPE_DOUBLE  : c_type = "double"; break;
+    case FieldDescriptor::TYPE_DOUBLE  : c_type =
+        "\n#if (__DBL_MANT_DIG__ != 53 && __LDBL_MANT_DIG__ == 53)\n"
+        "long double /* The target environment's native double type is not 64-bit, but its long double type is; use that. */\n"
+        "#elif (__DBL_MANT_DIG__ != 53)\n"
+        "#error: unable to locate a native 64-bit floating point type to support protobuf doubles!\n"
+        "#else\n"
+        "double\n"
+        "#endif\n"; break;
     case FieldDescriptor::TYPE_BOOL    : c_type = "protobuf_c_boolean"; break;
     case FieldDescriptor::TYPE_ENUM    : 
     case FieldDescriptor::TYPE_STRING  :


### PR DESCRIPTION
Some embedded compilers use 32-bit IEEE-754 floats as their native double
type.  The Microchip XC16 compiler is an example.  By default, XC16 uses
a 32-bit float for its native double.  This is only defeated if the
-fno-short-double flag is passed.

While uncommon, this behavior is not actually a violation of ANSI C.
Thus, for portability, it should be accommodated.  This commit adds the
necessary changes to protobuf-c to do so.  Auto-generated source output by
protobuf-c now includes proprocessor logic to conditionally use the target
environment's long double type to represent 64-bit protobuf doubles if the
target environment's native double type is not 64-bit, but its long double
is.

This is determined by examination of the __DBL_MANT_DIG__ macro from
float.h.  If __DLB_MANT_DIG__ == 53, then the target environment's native
double type is 64-bit, with 1 bit for sign, 11 bits for exponenent, 52
explicit bits for the mantissa and an implicit leading 1.  Likewise, the
same determination can be made for type long double by examination of the
__LDBL_MANT_DIG__ macro.  With the changes, auto-generated source will
fail compilation with #error if no 64-bit double type can be found in the
target environment.

Testing: Verified successful build of the protobuf-c compiler plugin.
Verified correct output of auto-generated source.  Verified successful
compilation of auto-generated source and protobuf-c.c with the Microchip
XC16 compiler, version 1.24.  Without the -fno-short-double switch, the
64-bit long double type was used for protobuf double fields.  With
-fno-short-double, compilation used the default double type.  Verified
that with both compiler configurations, the compiled code correctly
serialized protobuf doubles.  Before this change, compilation without
-fno-short-double resulted in incorrect serialization of protobuf doubles,
as the library's auto-generated source was erroneously assuming target
environment doubles were 64-bit double-precision IEEE-764 floats.

Signed-off-by: Michael Sandstedt <msandstedt@zeptolife.com>