### PR TITLE
.travis.yml: Bump protobuf version to 3.7.1, use new URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ addons:
 
 env:
   global:
-    - PROTOBUF_VERSION=3.6.1
+    - PROTOBUF_VERSION=3.7.1
     - PKG_CONFIG_PATH=$HOME/protobuf-$PROTOBUF_VERSION-bin/lib/pkgconfig
 
 install:
     - pip install --user cpp-coveralls
-    - wget https://github.com/google/protobuf/archive/v$PROTOBUF_VERSION.tar.gz
+    - wget https://github.com/protocolbuffers/protobuf/archive/v$PROTOBUF_VERSION.tar.gz
     - tar xf v$PROTOBUF_VERSION.tar.gz
     - ( cd protobuf-$PROTOBUF_VERSION && ./autogen.sh && ./configure --prefix=$HOME/protobuf-$PROTOBUF_VERSION-bin && make -j2 && make install )
 


### PR DESCRIPTION
This bumps the protobuf version built in Travis-CI to 3.7.1, which replicates the build failure in the test suite.