### PR TITLE
Added a second set of braces around 0 when initializing union in code…

### DIFF
--- a/protoc-c/c_message.cc
+++ b/protoc-c/c_message.cc
@@ -245,7 +245,7 @@ GenerateStructDefinition(io::Printer* printer) {
     // Initialize the case enum
     printer->Print(vars, ", $foneofname$__NOT_SET");
     // Initialize the union
-    printer->Print(", {0}");
+    printer->Print(", {{0}}");
   }
   printer->Print(" }\n\n\n");
 


### PR DESCRIPTION
… generator to fix the 'missing braces around initializer' error that some compilers give

Signed-off-by: Ethan Gibson <eagi223@g.uky.edu>

This fixes the following error given by some compilers when trying to compile a .pb-c.h containing a union (from a oneof in the .proto file).

`/Users/ethan/Documents/Development/RPH/rph_esp32_engine_gunbox_pro/main/protobuf/event.pb-c.h:188:2: error: missing braces around initializer [-Werror=missing-braces]
  { PROTOBUF_C_MESSAGE_INIT (&acceleration__descriptor) \`

This happens for me when using protobuf-c in an ESP-IDF project.
