### PR TITLE
Compiler warning and remarks cleanup

### DIFF
--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -2099,7 +2099,7 @@ typedef struct _ScannedMember ScannedMember;
 /** Field as it's being read. */
 struct _ScannedMember {
 	uint32_t tag;              /**< Field tag. */
-	uint8_t wire_type;         /**< Field type. */
+	ProtobufCWireType wire_type; /**< Field type. */
 	uint8_t length_prefix_len; /**< Prefix length. */
 	const ProtobufCFieldDescriptor *field; /**< Field descriptor. */
 	size_t len;                /**< Field length. */

--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -2075,7 +2075,7 @@ parse_tag_and_wiretype(size_t len,
 		return 0;
 	}
 
-	*wiretype_out = data[0] & 7;
+	*wiretype_out = (ProtobufCWireType)(data[0] & 7);
 	if ((data[0] & 0x80) == 0) {
 		*tag_out = tag;
 		return 1;


### PR DESCRIPTION
Better casting to clean up compiler warnings and remarks.

IAR Embedded Workbench for ARM 8.32.3.20228

Before changes:

> Remark[Pe193]: zero used for undefined preprocessing identifier "__GNUC__" E:\git\FW\protobuf_tracker\out\c\protobuf-c\protobuf-c\protobuf-c.h 225 
Remark[Pe193]: zero used for undefined preprocessing identifier "__GNUC__" E:\git\FW\protobuf_tracker\out\c\protobuf-c\protobuf-c\protobuf-c.h 225 
Remark[Pe193]: zero used for undefined preprocessing identifier "__GNUC__" E:\git\FW\protobuf_tracker\out\c\protobuf-c\protobuf-c\protobuf-c.h 225 
Remark[Pe193]: zero used for undefined preprocessing identifier "__GNUC__" E:\git\FW\protobuf_tracker\out\c\protobuf-c\protobuf-c\protobuf-c.h 225 
Remark[Pe826]: parameter "allocator_data" was never referenced E:\git\FW\protobuf_tracker\out\c\protobuf-c\protobuf-c\protobuf-c.c 149 
Remark[Pe826]: parameter "allocator_data" was never referenced E:\git\FW\protobuf_tracker\out\c\protobuf-c\protobuf-c\protobuf-c.c 155 
Remark[Pa109]: the unary minus operator is applied to an unsigned expression (with possibly unexpected results) E:\git\FW\protobuf_tracker\out\c\protobuf-c\protobuf-c\protobuf-c.c 316 
Remark[Pa109]: the unary minus operator is applied to an unsigned expression (with possibly unexpected results) E:\git\FW\protobuf_tracker\out\c\protobuf-c\protobuf-c\protobuf-c.c 381 
Warning[Pe188]: enumerated type mixed with another type E:\git\FW\protobuf_tracker\out\c\protobuf-c\protobuf-c\protobuf-c.c 2075 
Remark[Pa109]: the unary minus operator is applied to an unsigned expression (with possibly unexpected results) E:\git\FW\protobuf_tracker\out\c\protobuf-c\protobuf-c\protobuf-c.c 2415 
Remark[Pa109]: the unary minus operator is applied to an unsigned expression (with possibly unexpected results) E:\git\FW\protobuf_tracker\out\c\protobuf-c\protobuf-c\protobuf-c.c 2459 
Warning[Pe188]: enumerated type mixed with another type E:\git\FW\protobuf_tracker\out\c\protobuf-c\protobuf-c\protobuf-c.c 2495 
Warning[Pe188]: enumerated type mixed with another type E:\git\FW\protobuf_tracker\out\c\protobuf-c\protobuf-c\protobuf-c.c 2881 


After changes

> Remark[Pe193]: zero used for undefined preprocessing identifier "__GNUC__" E:\git\FW\protobuf_tracker\out\c\protobuf-c\protobuf-c\protobuf-c.h 225 
Remark[Pe193]: zero used for undefined preprocessing identifier "__GNUC__" E:\git\FW\protobuf_tracker\out\c\protobuf-c\protobuf-c\protobuf-c.h 225 

