### PR TITLE
Fix unsigned unary operator bug.

### DIFF
--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -312,10 +312,7 @@ int32_size(int32_t v)
 static inline uint32_t
 zigzag32(int32_t v)
 {
-	if (v < 0)
-		return (-(uint32_t)v) * 2 - 1;
-	else
-		return (uint32_t)(v) * 2;
+	return ((uint32_t)v << 1) ^ (((uint32_t)v >> 31));
 }
 
 /**
@@ -377,7 +374,7 @@ uint64_size(uint64_t v)
 static inline uint64_t
 zigzag64(int64_t v)
 {
-	return (((uint64_t)v) << 1) ^ ((uint64_t)(v >> 63));
+	return ((uint64_t)v << 1) ^ (((uint64_t)v >> 63));
 }
 
 /**
@@ -2461,7 +2458,7 @@ parse_uint64(unsigned len, const uint8_t *data)
 static inline int64_t
 unzigzag64(uint64_t v)
 {
-	return (int32_t)((v >> 1) ^ (~(v & 1) + 1));
+	return (int64_t)((v >> 1) ^ (~(v & 1) + 1));
 }
 
 static inline uint64_t

--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -377,10 +377,7 @@ uint64_size(uint64_t v)
 static inline uint64_t
 zigzag64(int64_t v)
 {
-	if (v < 0)
-		return (-(uint64_t)v) * 2 - 1;
-	else
-		return (uint64_t)(v) * 2;
+	return (((uint64_t)v) << 1) ^ ((uint64_t)(v >> 63));
 }
 
 /**
@@ -2423,10 +2420,7 @@ parse_int32(unsigned len, const uint8_t *data)
 static inline int32_t
 unzigzag32(uint32_t v)
 {
-	if (v & 1)
-		return -(v >> 1) - 1;
-	else
-		return v >> 1;
+	return (int32_t)((v >> 1) ^ (~(v & 1) + 1));
 }
 
 static inline uint32_t
@@ -2467,10 +2461,7 @@ parse_uint64(unsigned len, const uint8_t *data)
 static inline int64_t
 unzigzag64(uint64_t v)
 {
-	if (v & 1)
-		return -(v >> 1) - 1;
-	else
-		return v >> 1;
+	return (int32_t)((v >> 1) ^ (~(v & 1) + 1));
 }
 
 static inline uint64_t


### PR DESCRIPTION
This PR fixes the bug building with Visual Studio on Windows platforms.

protobuf-c.c(316): error C4146: unary minus operator applied to unsigne
d type, result still unsigned

protobuf-c\protobuf-c.c(381): error C4146: unary minus operator applied to unsigne
d type, result still unsigned

Please refer to PR for google protobuf project. https://github.com/protocolbuffers/protobuf/pull/4000
