### PR TITLE
protobuf-c.c: Make zigzag encoding more compact

### DIFF
--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -312,10 +312,9 @@ int32_size(int32_t v)
 static inline uint32_t
 zigzag32(int32_t v)
 {
-	if (v < 0)
-		return (-(uint32_t)v) * 2 - 1;
-	else
-		return (uint32_t)(v) * 2;
+	// Note:  the right-shift must be arithmetic
+	// Note:  left shift must be unsigned because of overflow
+	return ((uint32_t)(v) << 1) ^ (uint32_t)(v >> 31);
 }
 
 /**
@@ -377,10 +376,9 @@ uint64_size(uint64_t v)
 static inline uint64_t
 zigzag64(int64_t v)
 {
-	if (v < 0)
-		return (-(uint64_t)v) * 2 - 1;
-	else
-		return (uint64_t)(v) * 2;
+	// Note:  the right-shift must be arithmetic
+	// Note:  left shift must be unsigned because of overflow
+	return ((uint64_t)(v) << 1) ^ (uint64_t)(v >> 63);
 }
 
 /**
@@ -2423,10 +2421,8 @@ parse_int32(unsigned len, const uint8_t *data)
 static inline int32_t
 unzigzag32(uint32_t v)
 {
-	if (v & 1)
-		return -(v >> 1) - 1;
-	else
-		return v >> 1;
+	// Note:  Using unsigned types prevents undefined behavior
+	return (int32_t)((v >> 1) ^ (~(v & 1) + 1));
 }
 
 static inline uint32_t
@@ -2467,10 +2463,8 @@ parse_uint64(unsigned len, const uint8_t *data)
 static inline int64_t
 unzigzag64(uint64_t v)
 {
-	if (v & 1)
-		return -(v >> 1) - 1;
-	else
-		return v >> 1;
+	// Note:  Using unsigned types prevents undefined behavior
+	return (int64_t)((v >> 1) ^ (~(v & 1) + 1));
 }
 
 static inline uint64_t


### PR DESCRIPTION
Also match upstream code in src/google/protobuf/wire_format_lite.h

See https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/wire_format_lite.h