### PR TITLE
Endless cycle in `protobuf_c_buffer_simple_append` function

### DIFF
--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -192,7 +192,7 @@ protobuf_c_buffer_simple_append(ProtobufCBuffer *buffer,
 
 	if (new_len > simp->alloced) {
 		ProtobufCAllocator *allocator = simp->allocator;
-		size_t new_alloced = simp->alloced * 2;
+		size_t new_alloced = (simp->alloced ? simp->alloced * 2 : new_len);
 		uint8_t *new_data;
 
 		if (allocator == NULL)


### PR DESCRIPTION
If we write analog PROTOBUF_C_BUFFER_SIMPLE_INIT, but for dynamic allocated buffer (see PROTOBUF_C_BUFFER_SIMPLE_INIT_NULL) and initialize it as null, 'protobuf_c_buffer_simple_append' goes into an endless cycle.

Example:
```
#define PROTOBUF_C_BUFFER_SIMPLE_INIT_NULL                   \
{                                                                       \
    { protobuf_c_buffer_simple_append },                            \
    0,                                         \
    0,                                                              \
    0,                                               \
    0,                                                              \
    NULL                                                            \
}

ProtobufCBufferSimple simple = PROTOBUF_C_BUFFER_SIMPLE_INIT_NULL;
size_t len = test__data__pack_to_buffer (t, (ProtobufCBuffer*)&simple);
```
Goes into an endless cycle in `protobuf_c_buffer_simple_append` function!

Fix in `protobuf_c_buffer_simple_append`:
```
		size_t new_alloced = simp->alloced * 2;
...
		while (new_alloced < new_len) // << endless loop if simp->alloced == 0
			new_alloced += new_alloced;
```
TO:
```
		size_t new_alloced = (simp->alloced ? simp->alloced * 2 : new_len);
```
