### PR TITLE
generate all code, even for submessages

### DIFF
--- a/protoc-c/c_message.cc
+++ b/protoc-c/c_message.cc
@@ -266,7 +266,7 @@ GenerateHelperFunctionDeclarations(io::Printer* printer, bool is_submessage)
 		 "void   $lcclassname$__init\n"
 		 "                     ($classname$         *message);\n"
 		);
-  if (!is_submessage) {
+  // if (!is_submessage) {
     printer->Print(vars,
 		 "size_t $lcclassname$__get_packed_size\n"
 		 "                     (const $classname$   *message);\n"
@@ -285,7 +285,7 @@ GenerateHelperFunctionDeclarations(io::Printer* printer, bool is_submessage)
 		 "                     ($classname$ *message,\n"
 		 "                      ProtobufCAllocator *allocator);\n"
 		);
-  }
+  // }
 }
 
 void MessageGenerator::
@@ -342,7 +342,7 @@ GenerateHelperFunctionDefinitions(io::Printer* printer, bool is_submessage)
 		 "  static const $classname$ init_value = $ucclassname$__INIT;\n"
 		 "  *message = init_value;\n"
 		 "}\n");
-  if (!is_submessage) {
+  // if (!is_submessage) {
     printer->Print(vars,
 		 "size_t $lcclassname$__get_packed_size\n"
 		 "                     (const $classname$ *message)\n"
@@ -384,7 +384,7 @@ GenerateHelperFunctionDefinitions(io::Printer* printer, bool is_submessage)
 		 "  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);\n"
 		 "}\n"
 		);
-  }
+  // }
 }
 
 void MessageGenerator::


### PR DESCRIPTION
Hey guys,

This was made as an answer to #240 which I would also need, as it is a useful feature when implementing "union" like messages.

Obviously this isn't an actual patch, I just commented out the lines that specifically disable the behaviour I'd like, but I hoped to show more interest for this feature and maybe we can discuss how/if you want that feature implemented (always on, command-line option, build-time arg...)
 
Thanks.