### PR TITLE
Supporting linux kernel

### DIFF
--- a/protobuf-c/Makefile
+++ b/protobuf-c/Makefile
@@ -1,0 +1,9 @@
+obj-m += protobuf-c.o
+EXTRA_CFLAGS=-I$(PWD)
+KDIR?=/lib/modules/$(shell uname -r)/build
+
+all:
+	make -C $(KDIR) M=$(PWD) modules
+
+clean:
+	make -C $(KDIR) M=$(PWD) clean

--- a/protobuf-c/libprotobuf-c.sym
+++ b/protobuf-c/libprotobuf-c.sym
@@ -1,6 +1,7 @@
 LIBPROTOBUF_C_1.0.0 {
 global:
         protobuf_c_buffer_simple_append;
+        protobuf_c_buffer_simple_clear;
         protobuf_c_enum_descriptor_get_value;
         protobuf_c_enum_descriptor_get_value_by_name;
         protobuf_c_message_check;

--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -45,8 +45,31 @@
  * \todo Use size_t consistently.
  */
 
-#include <stdlib.h>	/* for malloc, free */
-#include <string.h>	/* for strcmp, strlen, memcpy, memmove, memset */
+#ifndef __KERNEL__
+# include <stdlib.h>	/* for malloc, free */
+# include <string.h>	/* for strcmp, strlen, memcpy, memmove, memset */
+#else /* __KERNEL__ */
+# include <linux/module.h>
+# include <linux/slab.h>
+# include <linux/string.h>
+
+#define assert(exp) WARN_ON(!(exp))
+
+MODULE_LICENSE("Dual BSD/GPL");
+MODULE_VERSION("0.1");
+
+static int __init init_protobuf_c(void)
+{
+	return 0;
+}
+
+static void __exit exit_protobuf_c(void)
+{
+}
+
+module_init(init_protobuf_c);
+module_exit(exit_protobuf_c);
+#endif /* __KERNEL__ */
 
 #include "protobuf-c.h"
 
@@ -144,7 +167,7 @@ protobuf_c_version_number(void)
 }
 
 /* --- allocator --- */
-
+#ifndef __KERNEL__
 static void *
 system_alloc(void *allocator_data, size_t size)
 {
@@ -156,6 +179,21 @@ system_free(void *allocator_data, void *data)
 {
 	free(data);
 }
+
+#else /* __KERNEL__ */
+
+static void *
+system_alloc(void *allocator_data, size_t size)
+{
+	return kmalloc(size, GFP_KERNEL);
+}
+
+static void
+system_free(void *allocator_data, void *data)
+{
+	kfree(data);
+}
+#endif /* __KERNEL__ */
 
 static inline void *
 do_alloc(ProtobufCAllocator *allocator, size_t size)
@@ -182,6 +220,20 @@ static ProtobufCAllocator protobuf_c__allocator = {
 };
 
 /* === buffer-simple === */
+
+void
+protobuf_c_buffer_simple_clear(ProtobufCBufferSimple *simp)
+{
+	if (simp->must_free_data) {
+		if (simp->allocator != NULL)
+			simp->allocator->free(
+					simp->allocator,
+					simp->data);
+		else
+			system_free(NULL, simp->data);
+	}
+}
+
 
 void
 protobuf_c_buffer_simple_append(ProtobufCBuffer *buffer,
@@ -437,10 +489,12 @@ required_field_get_packed_size(const ProtobufCFieldDescriptor *field,
 		return rv + 8;
 	case PROTOBUF_C_TYPE_BOOL:
 		return rv + 1;
+#ifndef __KERNEL__
 	case PROTOBUF_C_TYPE_FLOAT:
 		return rv + 4;
 	case PROTOBUF_C_TYPE_DOUBLE:
 		return rv + 8;
+#endif /* __KERNEL__ */
 	case PROTOBUF_C_TYPE_STRING: {
 		const char *str = *(char * const *) member;
 		size_t len = str ? strlen(str) : 0;
@@ -549,12 +603,14 @@ field_is_zeroish(const ProtobufCFieldDescriptor *field,
 	case PROTOBUF_C_TYPE_FIXED64:
 		ret = (0 == *(const uint64_t *) member);
 		break;
+#ifndef __KERNEL__
 	case PROTOBUF_C_TYPE_FLOAT:
 		ret = (0 == *(const float *) member);
 		break;
 	case PROTOBUF_C_TYPE_DOUBLE:
 		ret = (0 == *(const double *) member);
 		break;
+#endif /* __KERNEL__ */
 	case PROTOBUF_C_TYPE_STRING:
 		ret = (NULL == *(const char * const *) member) ||
 		      ('\0' == **(const char * const *) member);
@@ -647,14 +703,18 @@ repeated_field_get_packed_size(const ProtobufCFieldDescriptor *field,
 		break;
 	case PROTOBUF_C_TYPE_SFIXED32:
 	case PROTOBUF_C_TYPE_FIXED32:
+#ifndef __KERNEL__
 	case PROTOBUF_C_TYPE_FLOAT:
 		rv += 4 * count;
 		break;
+#endif /* __KERNEL__ */
 	case PROTOBUF_C_TYPE_SFIXED64:
 	case PROTOBUF_C_TYPE_FIXED64:
+#ifndef __KERNEL__
 	case PROTOBUF_C_TYPE_DOUBLE:
 		rv += 8 * count;
 		break;
+#endif /* __KERNEL__ */
 	case PROTOBUF_C_TYPE_BOOL:
 		rv += count;
 		break;
@@ -683,6 +743,10 @@ repeated_field_get_packed_size(const ProtobufCFieldDescriptor *field,
 		header_size += uint32_size(rv);
 	return header_size + rv;
 }
+
+#ifdef __KERNEL__
+EXPORT_SYMBOL(protobuf_c_message_get_packed_size);
+#endif /* __KERNEL__ */
 
 /**
  * Calculate the serialized size of an unknown field, i.e. one that is passed
@@ -1111,14 +1175,18 @@ required_field_pack(const ProtobufCFieldDescriptor *field,
 		return rv + uint64_pack(*(const uint64_t *) member, out + rv);
 	case PROTOBUF_C_TYPE_SFIXED32:
 	case PROTOBUF_C_TYPE_FIXED32:
+#ifndef __KERNEL__
 	case PROTOBUF_C_TYPE_FLOAT:
 		out[0] |= PROTOBUF_C_WIRE_TYPE_32BIT;
 		return rv + fixed32_pack(*(const uint32_t *) member, out + rv);
+#endif /* __KERNEL__ */
 	case PROTOBUF_C_TYPE_SFIXED64:
 	case PROTOBUF_C_TYPE_FIXED64:
+#ifndef __KERNEL__
 	case PROTOBUF_C_TYPE_DOUBLE:
 		out[0] |= PROTOBUF_C_WIRE_TYPE_64BIT;
 		return rv + fixed64_pack(*(const uint64_t *) member, out + rv);
+#endif /* __KERNEL__ */
 	case PROTOBUF_C_TYPE_BOOL:
 		out[0] |= PROTOBUF_C_WIRE_TYPE_VARINT;
 		return rv + boolean_pack(*(const protobuf_c_boolean *) member, out + rv);
@@ -1241,7 +1309,9 @@ sizeof_elt_in_repeated_array(ProtobufCType type)
 	case PROTOBUF_C_TYPE_UINT32:
 	case PROTOBUF_C_TYPE_SFIXED32:
 	case PROTOBUF_C_TYPE_FIXED32:
+#ifndef __KERNEL__
 	case PROTOBUF_C_TYPE_FLOAT:
+#endif /* __KERNEL__ */
 	case PROTOBUF_C_TYPE_ENUM:
 		return 4;
 	case PROTOBUF_C_TYPE_SINT64:
@@ -1249,8 +1319,10 @@ sizeof_elt_in_repeated_array(ProtobufCType type)
 	case PROTOBUF_C_TYPE_UINT64:
 	case PROTOBUF_C_TYPE_SFIXED64:
 	case PROTOBUF_C_TYPE_FIXED64:
+#ifndef __KERNEL__
 	case PROTOBUF_C_TYPE_DOUBLE:
 		return 8;
+#endif /* __KERNEL__ */
 	case PROTOBUF_C_TYPE_BOOL:
 		return sizeof(protobuf_c_boolean);
 	case PROTOBUF_C_TYPE_STRING:
@@ -1322,14 +1394,20 @@ static unsigned
 get_type_min_size(ProtobufCType type)
 {
 	if (type == PROTOBUF_C_TYPE_SFIXED32 ||
-	    type == PROTOBUF_C_TYPE_FIXED32 ||
-	    type == PROTOBUF_C_TYPE_FLOAT)
+	    type == PROTOBUF_C_TYPE_FIXED32
+#ifndef __KERNEL__
+	    || type == PROTOBUF_C_TYPE_FLOAT
+#endif /* __KERNEL__ */
+		)
 	{
 		return 4;
 	}
 	if (type == PROTOBUF_C_TYPE_SFIXED64 ||
-	    type == PROTOBUF_C_TYPE_FIXED64 ||
-	    type == PROTOBUF_C_TYPE_DOUBLE)
+	    type == PROTOBUF_C_TYPE_FIXED64
+#ifndef __KERNEL__
+	    || type == PROTOBUF_C_TYPE_DOUBLE
+#endif /* __KERNEL__ */
+		)
 	{
 		return 8;
 	}
@@ -1380,13 +1458,17 @@ repeated_field_pack(const ProtobufCFieldDescriptor *field,
 		switch (field->type) {
 		case PROTOBUF_C_TYPE_SFIXED32:
 		case PROTOBUF_C_TYPE_FIXED32:
+#ifndef __KERNEL__
 		case PROTOBUF_C_TYPE_FLOAT:
+#endif /* __KERNEL__ */
 			copy_to_little_endian_32(payload_at, array, count);
 			payload_at += count * 4;
 			break;
 		case PROTOBUF_C_TYPE_SFIXED64:
 		case PROTOBUF_C_TYPE_FIXED64:
+#ifndef __KERNEL__
 		case PROTOBUF_C_TYPE_DOUBLE:
+#endif /* __KERNEL__ */
 			copy_to_little_endian_64(payload_at, array, count);
 			payload_at += count * 8;
 			break;
@@ -1521,6 +1603,10 @@ protobuf_c_message_pack(const ProtobufCMessage *message, uint8_t *out)
 	return rv;
 }
 
+#ifdef __KERNEL__
+EXPORT_SYMBOL(protobuf_c_message_pack);
+#endif /* __KERNEL__ */
+
 /**
  * \defgroup packbuf protobuf_c_message_pack_to_buffer() implementation
  *
@@ -1580,18 +1666,22 @@ required_field_pack_to_buffer(const ProtobufCFieldDescriptor *field,
 		break;
 	case PROTOBUF_C_TYPE_SFIXED32:
 	case PROTOBUF_C_TYPE_FIXED32:
+#ifndef __KERNEL__
 	case PROTOBUF_C_TYPE_FLOAT:
 		scratch[0] |= PROTOBUF_C_WIRE_TYPE_32BIT;
 		rv += fixed32_pack(*(const uint32_t *) member, scratch + rv);
 		buffer->append(buffer, rv, scratch);
 		break;
+#endif /* __KERNEL__ */
 	case PROTOBUF_C_TYPE_SFIXED64:
 	case PROTOBUF_C_TYPE_FIXED64:
+#ifndef __KERNEL__
 	case PROTOBUF_C_TYPE_DOUBLE:
 		scratch[0] |= PROTOBUF_C_WIRE_TYPE_64BIT;
 		rv += fixed64_pack(*(const uint64_t *) member, scratch + rv);
 		buffer->append(buffer, rv, scratch);
 		break;
+#endif /* __KERNEL__ */
 	case PROTOBUF_C_TYPE_BOOL:
 		scratch[0] |= PROTOBUF_C_WIRE_TYPE_VARINT;
 		rv += boolean_pack(*(const protobuf_c_boolean *) member, scratch + rv);
@@ -1635,7 +1725,7 @@ required_field_pack_to_buffer(const ProtobufCFieldDescriptor *field,
 		buffer->append(buffer, rv, scratch);
 		buffer->append(buffer, sublen, simple_buffer.data);
 		rv += sublen;
-		PROTOBUF_C_BUFFER_SIMPLE_CLEAR(&simple_buffer);
+		protobuf_c_buffer_simple_clear(&simple_buffer);
 		break;
 	}
 	default:
@@ -1751,11 +1841,15 @@ get_packed_payload_length(const ProtobufCFieldDescriptor *field,
 	switch (field->type) {
 	case PROTOBUF_C_TYPE_SFIXED32:
 	case PROTOBUF_C_TYPE_FIXED32:
+#ifndef __KERNEL__
 	case PROTOBUF_C_TYPE_FLOAT:
+#endif /* __KERNEL__ */
 		return count * 4;
 	case PROTOBUF_C_TYPE_SFIXED64:
 	case PROTOBUF_C_TYPE_FIXED64:
+#ifndef __KERNEL__
 	case PROTOBUF_C_TYPE_DOUBLE:
+#endif /* __KERNEL__ */
 		return count * 8;
 	case PROTOBUF_C_TYPE_ENUM:
 	case PROTOBUF_C_TYPE_INT32: {
@@ -1823,7 +1917,9 @@ pack_buffer_packed_payload(const ProtobufCFieldDescriptor *field,
 	switch (field->type) {
 	case PROTOBUF_C_TYPE_SFIXED32:
 	case PROTOBUF_C_TYPE_FIXED32:
+#ifndef __KERNEL__
 	case PROTOBUF_C_TYPE_FLOAT:
+#endif /* __KERNEL__ */
 #if !defined(WORDS_BIGENDIAN)
 		rv = count * 4;
 		goto no_packing_needed;
@@ -1837,7 +1933,9 @@ pack_buffer_packed_payload(const ProtobufCFieldDescriptor *field,
 #endif
 	case PROTOBUF_C_TYPE_SFIXED64:
 	case PROTOBUF_C_TYPE_FIXED64:
+#ifndef __KERNEL__
 	case PROTOBUF_C_TYPE_DOUBLE:
+#endif /* __KERNEL__ */
 #if !defined(WORDS_BIGENDIAN)
 		rv = count * 8;
 		goto no_packing_needed;
@@ -2010,6 +2108,10 @@ protobuf_c_message_pack_to_buffer(const ProtobufCMessage *message,
 
 	return rv;
 }
+
+#ifdef __KERNEL__
+EXPORT_SYMBOL(protobuf_c_message_pack_to_buffer);
+#endif /* __KERNEL__ */
 
 /**
  * \defgroup unpack unpacking implementation
@@ -2359,7 +2461,9 @@ count_packed_elements(ProtobufCType type,
 	switch (type) {
 	case PROTOBUF_C_TYPE_SFIXED32:
 	case PROTOBUF_C_TYPE_FIXED32:
+#ifndef __KERNEL__
 	case PROTOBUF_C_TYPE_FLOAT:
+#endif /* __KERNEL__ */
 		if (len % 4 != 0) {
 			PROTOBUF_C_UNPACK_ERROR("length must be a multiple of 4 for fixed-length 32-bit types");
 			return FALSE;
@@ -2368,7 +2472,9 @@ count_packed_elements(ProtobufCType type,
 		return TRUE;
 	case PROTOBUF_C_TYPE_SFIXED64:
 	case PROTOBUF_C_TYPE_FIXED64:
+#ifndef __KERNEL__
 	case PROTOBUF_C_TYPE_DOUBLE:
+#endif /* __KERNEL__ */
 		if (len % 8 != 0) {
 			PROTOBUF_C_UNPACK_ERROR("length must be a multiple of 8 for fixed-length 64-bit types");
 			return FALSE;
@@ -2525,7 +2631,9 @@ parse_required_member(ScannedMember *scanned_member,
 		return TRUE;
 	case PROTOBUF_C_TYPE_SFIXED32:
 	case PROTOBUF_C_TYPE_FIXED32:
+#ifndef __KERNEL__
 	case PROTOBUF_C_TYPE_FLOAT:
+#endif /* __KERNEL__ */
 		if (wire_type != PROTOBUF_C_WIRE_TYPE_32BIT)
 			return FALSE;
 		*(uint32_t *) member = parse_fixed_uint32(data);
@@ -2543,7 +2651,9 @@ parse_required_member(ScannedMember *scanned_member,
 		return TRUE;
 	case PROTOBUF_C_TYPE_SFIXED64:
 	case PROTOBUF_C_TYPE_FIXED64:
+#ifndef __KERNEL__
 	case PROTOBUF_C_TYPE_DOUBLE:
+#endif /* __KERNEL__ */
 		if (wire_type != PROTOBUF_C_WIRE_TYPE_64BIT)
 			return FALSE;
 		*(uint64_t *) member = parse_fixed_uint64(data);
@@ -2758,7 +2868,9 @@ parse_packed_repeated_member(ScannedMember *scanned_member,
 	switch (field->type) {
 	case PROTOBUF_C_TYPE_SFIXED32:
 	case PROTOBUF_C_TYPE_FIXED32:
+#ifndef __KERNEL__
 	case PROTOBUF_C_TYPE_FLOAT:
+#endif /* __KERNEL__ */
 		count = (scanned_member->len - scanned_member->length_prefix_len) / 4;
 #if !defined(WORDS_BIGENDIAN)
 		goto no_unpacking_needed;
@@ -2771,7 +2883,9 @@ parse_packed_repeated_member(ScannedMember *scanned_member,
 #endif
 	case PROTOBUF_C_TYPE_SFIXED64:
 	case PROTOBUF_C_TYPE_FIXED64:
+#ifndef __KERNEL__
 	case PROTOBUF_C_TYPE_DOUBLE:
+#endif /* __KERNEL__ */
 		count = (scanned_member->len - scanned_member->length_prefix_len) / 8;
 #if !defined(WORDS_BIGENDIAN)
 		goto no_unpacking_needed;
@@ -2960,7 +3074,9 @@ message_init_generic(const ProtobufCMessageDescriptor *desc,
 			case PROTOBUF_C_TYPE_SFIXED32:
 			case PROTOBUF_C_TYPE_UINT32:
 			case PROTOBUF_C_TYPE_FIXED32:
+#ifndef  __KERNEL__
 			case PROTOBUF_C_TYPE_FLOAT:
+#endif /* __KERNEL__ */
 			case PROTOBUF_C_TYPE_ENUM:
 				memcpy(field, dv, 4);
 				break;
@@ -2969,7 +3085,9 @@ message_init_generic(const ProtobufCMessageDescriptor *desc,
 			case PROTOBUF_C_TYPE_SFIXED64:
 			case PROTOBUF_C_TYPE_UINT64:
 			case PROTOBUF_C_TYPE_FIXED64:
+#ifndef  __KERNEL__
 			case PROTOBUF_C_TYPE_DOUBLE:
+#endif /* __KERNEL__ */
 				memcpy(field, dv, 8);
 				break;
 			case PROTOBUF_C_TYPE_BOOL:
@@ -3314,6 +3432,10 @@ error_cleanup_during_scan:
 	return NULL;
 }
 
+#ifdef __KERNEL__
+EXPORT_SYMBOL(protobuf_c_message_unpack);
+#endif /* __KERNEL__ */
+
 void
 protobuf_c_message_free_unpacked(ProtobufCMessage *message,
 				 ProtobufCAllocator *allocator)
@@ -3402,6 +3524,10 @@ protobuf_c_message_free_unpacked(ProtobufCMessage *message,
 
 	do_free(allocator, message);
 }
+
+#ifdef __KERNEL__
+EXPORT_SYMBOL(protobuf_c_message_free_unpacked);
+#endif /* __KERNEL__ */
 
 void
 protobuf_c_message_init(const ProtobufCMessageDescriptor * descriptor,

--- a/protobuf-c/protobuf-c.h
+++ b/protobuf-c/protobuf-c.h
@@ -196,10 +196,17 @@ size_t foo__bar__baz_bah__pack_to_buffer
 #ifndef PROTOBUF_C_H
 #define PROTOBUF_C_H
 
-#include <assert.h>
-#include <limits.h>
-#include <stddef.h>
-#include <stdint.h>
+#ifdef __KERNEL__
+# include <linux/bug.h>
+# include <linux/kernel.h>
+# include <linux/types.h>
+# define assert(exp) WARN_ON(!(exp))
+#else /* __KERNEL__ */
+# include <assert.h>
+# include <limits.h>
+# include <stddef.h>
+# include <stdint.h>
+#endif /* __KERNEL__ */
 
 #ifdef __cplusplus
 # define PROTOBUF_C__BEGIN_DECLS	extern "C" {
@@ -314,8 +321,10 @@ typedef enum {
 	PROTOBUF_C_TYPE_FIXED32,    /**< unsigned int32 (4 bytes) */
 	PROTOBUF_C_TYPE_UINT64,     /**< unsigned int64 */
 	PROTOBUF_C_TYPE_FIXED64,    /**< unsigned int64 (8 bytes) */
+#ifndef __KERNEL__
 	PROTOBUF_C_TYPE_FLOAT,      /**< float */
 	PROTOBUF_C_TYPE_DOUBLE,     /**< double */
+#endif /* __KERNEL__ */
 	PROTOBUF_C_TYPE_BOOL,       /**< boolean */
 	PROTOBUF_C_TYPE_ENUM,       /**< enumerated type */
 	PROTOBUF_C_TYPE_STRING,     /**< UTF-8 or ASCII string */
@@ -465,14 +474,14 @@ ProtobufCBuffer *buffer = (ProtobufCBuffer *) &simple;
  * serialized data bytes can be accessed from the `.data` field.
  *
  * To free the memory allocated by a `ProtobufCBufferSimple` object, if any,
- * call PROTOBUF_C_BUFFER_SIMPLE_CLEAR() on the object, for example:
+ * call protobuf_c_buffer_simple_clear() on the object, for example:
  *
 ~~~{.c}
-PROTOBUF_C_BUFFER_SIMPLE_CLEAR(&simple);
+protobuf_c_buffer_simple_clear(&simple);
 ~~~
  *
  * \see PROTOBUF_C_BUFFER_SIMPLE_INIT
- * \see PROTOBUF_C_BUFFER_SIMPLE_CLEAR
+ * \see protobuf_c_buffer_simple_clear
  */
 struct ProtobufCBufferSimple {
 	/** "Base class". */
@@ -1053,17 +1062,9 @@ protobuf_c_service_descriptor_get_method_by_name(
 /**
  * Clear a `ProtobufCBufferSimple` object, freeing any allocated memory.
  */
-#define PROTOBUF_C_BUFFER_SIMPLE_CLEAR(simp_buf)                        \
-do {                                                                    \
-	if ((simp_buf)->must_free_data) {                               \
-		if ((simp_buf)->allocator != NULL)                      \
-			(simp_buf)->allocator->free(                    \
-				(simp_buf)->allocator,                  \
-				(simp_buf)->data);			\
-		else                                                    \
-			free((simp_buf)->data);                         \
-	}                                                               \
-} while (0)
+PROTOBUF_C__API
+void
+protobuf_c_buffer_simple_clear(ProtobufCBufferSimple *simp);
 
 /**
  * The `append` method for `ProtobufCBufferSimple`.

--- a/t/generated-code/test-generated-code.c
+++ b/t/generated-code/test-generated-code.c
@@ -46,7 +46,7 @@ int main(void)
   assert (bs.len == size);
   assert (memcmp (bs.data, packed, size) == 0);
 
-  PROTOBUF_C_BUFFER_SIMPLE_CLEAR (&bs);
+  protobuf_c_buffer_simple_clear (&bs);
 
   person2 = foo__person__unpack (NULL, size, packed);
   assert (person2 != NULL);

--- a/t/generated-code2/test-generated-code2.c
+++ b/t/generated-code2/test-generated-code2.c
@@ -77,7 +77,7 @@ test_compare_pack_methods (ProtobufCMessage *message,
   assert (memcmp (bs.data, packed1, siz1) == 0);
   rv = protobuf_c_message_unpack (message->descriptor, NULL, siz1, packed1);
   assert (rv != NULL);
-  PROTOBUF_C_BUFFER_SIMPLE_CLEAR (&bs);
+  protobuf_c_buffer_simple_clear (&bs);
   *packed_len_out = siz1;
   *packed_out = packed1;
   return rv;


### PR DESCRIPTION
Rebase of https://github.com/protobuf-c/protobuf-c/pull/381 to the current next branch.

Added makefile that compiles protobuf-c.ko (similiar to libprotobuf-c.a). After protobuf-c.ko is loaded, kernel code that uses protobuf can run - all that is needed is to include the header generated by protoc.

This PR does a fix which IMO is necessary regardless of the kernel support which is to use system_free in protobuf_c_buffer_simple_clear (instead of just calling free() ), so if you would like, I will extract only this part to a separate PR.

I am using this kernel support in a project I'm working on, which will become public in the following weeks. I'll comment with it when it's public.