### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ This is `protobuf-c`, a C implementation of the [Google Protocol Buffers](https:
 
 `protobuf-c`'s mailing list is hosted on a [Google Groups forum](https://groups.google.com/forum/#!forum/protobuf-c). Subscribe by sending an email to [protobuf-c+subscribe@googlegroups.com](mailto:protobuf-c+subscribe@googlegroups.com).
 
+## Installing and building - use vcpkg
+
+You can download and install `protobuf-c` using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install protobuf-c
+    
+The `protobuf-c` port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Building
 
 `protobuf-c` requires a C compiler, a C++ compiler, [protobuf](https://github.com/google/protobuf), and `pkg-config` to be installed.


### PR DESCRIPTION
`protobuf-c`  is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `protobuf-c` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `protobuf-c`, ready to be included in their projects.

We also test whether our library ports build in various platforms (OSX, Linux) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/protobuf-c/portfile.cmake). We try to keep the library maintained as close as possible to the original library.