### PR TITLE
protobuf-c.h: Fix Windows DLL export (Fixes #331)

### DIFF
--- a/protobuf-c/protobuf-c.h
+++ b/protobuf-c/protobuf-c.h
@@ -238,7 +238,7 @@ PROTOBUF_C__BEGIN_DECLS
 #define PROTOBUF_C__ENUM_DESCRIPTOR_MAGIC       0x114315af
 
 /* Empty string used for initializers */
-extern const char protobuf_c_empty_string[];
+PROTOBUF_C__API extern const char protobuf_c_empty_string[];
 
 /**
  * \defgroup api Public API


### PR DESCRIPTION
protobuf_c_empty_string is used in generated .pb-c.{c,h} files so it
should be exported properly. Fixes #331 