### PR TITLE
Fixed compiler warning on static init oneof field

### DIFF
--- a/protoc-c/c_message.cc
+++ b/protoc-c/c_message.cc
@@ -245,7 +245,10 @@ GenerateStructDefinition(io::Printer* printer) {
     // Initialize the case enum
     printer->Print(vars, ", $foneofname$__NOT_SET");
     // Initialize the union
-    printer->Print(", {0}");
+    printer->Print(", {");
+    const FieldDescriptor* field = oneof->field(0);
+    field_generators_.get(field).GenerateStaticInit(printer);
+    printer->Print("}");
   }
   printer->Print(" }\n\n\n");
 


### PR DESCRIPTION
The oneof field is a union and initialized by "0" in generated header file. But
the protobuf type "bytes" is stored using ProtobufCBinaryData. If bytes is the
first field of the "oneof", the "oneof" should be initialized by "{0,NULL}".

Some compilers report warning if "-Wall" is enabled:

In file included from test.c:1:
test.pb-c.h:43:2: warning: missing braces around initializer [-Wmissing-braces]
   43 |  { PROTOBUF_C_MESSAGE_INIT (&base__descriptor) \
      |  ^
test.c:3:10: note: in expansion of macro ‘BASE__INIT’
    3 | Base x = BASE__INIT;
      |          ^~~~~~~~~~

And if "-Werror" is enabled, the source code will not compile.

This patch fixed this issue by initializing the "oneof" with the first field.

Signed-off-by: Zhai Zhaoxuan <kxuanobj@gmail.com>