### PR TITLE
Travis CI: Test on other platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language:
     - c
     - cpp
 
+arch:
+  - amd64
+  - arm64
+  - ppc64le
+  - s390x
+
 dist: bionic
 
 addons:
@@ -30,4 +36,6 @@ script:
     - ( mkdir build-cmake/bin && cd build-cmake/bin && cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=protobuf-c-bin ../ && make -j2 && make test && make install)
 
 after_success:
-    - cpp-coveralls --build-root . --exclude t/ --exclude /usr/include --exclude protobuf-$PROTOBUF_VERSION --exclude protoc-c
+    - if [ $(uname -m) = "x86_64" ]; then
+        cpp-coveralls --build-root . --exclude t/ --exclude /usr/include --exclude protobuf-$PROTOBUF_VERSION --exclude protoc-c;
+      fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language:
     - c
     - cpp
 
-sudo: required
-dist: xenial
+dist: bionic
 
 addons:
   apt:


### PR DESCRIPTION
Travis CI supports arm64, s390x and ppc64le now. It would be nice to test on those platforms, you get all sorts of interesting quirks (s390x is big-endian, for example).

If any issues come up with the ppc64le build in future, feel free to tag me in and I'll have a look - I have access to ppc64le systems at work. I can also help find a s390x person if that goes wrong there.

This involves bumping the Travis environment to Bionic, I don't think that will cause any dramas, it just gives us access to more recent compilers.