### PR TITLE
Add generator parameter to disable message pack/unpack wrappers

### DIFF
--- a/protoc-c/c_file.cc
+++ b/protoc-c/c_file.cc
@@ -80,7 +80,8 @@ namespace c {
 // ===================================================================
 
 FileGenerator::FileGenerator(const FileDescriptor* file,
-                             const std::string& dllexport_decl)
+                             const std::string& dllexport_decl,
+                             bool generate_helpers)
   : file_(file),
     message_generators_(
       new std::unique_ptr<MessageGenerator>[file->message_type_count()]),
@@ -93,7 +94,7 @@ FileGenerator::FileGenerator(const FileDescriptor* file,
 
   for (int i = 0; i < file->message_type_count(); i++) {
     message_generators_[i].reset(
-      new MessageGenerator(file->message_type(i), dllexport_decl));
+      new MessageGenerator(file->message_type(i), dllexport_decl, generate_helpers));
   }
 
   for (int i = 0; i < file->enum_type_count(); i++) {

--- a/protoc-c/c_file.h
+++ b/protoc-c/c_file.h
@@ -90,7 +90,8 @@ class FileGenerator {
  public:
   // See generator.cc for the meaning of dllexport_decl.
   explicit FileGenerator(const FileDescriptor* file,
-                         const std::string& dllexport_decl);
+                         const std::string& dllexport_decl,
+                         bool generate_helpers = true);
   ~FileGenerator();
 
   void GenerateHeader(io::Printer* printer);

--- a/protoc-c/c_generator.cc
+++ b/protoc-c/c_generator.cc
@@ -131,9 +131,18 @@ bool CGenerator::Generate(const FileDescriptor* file,
   // __declspec(dllimport) depending on what is being compiled.
   std::string dllexport_decl;
 
+  // By default, message pack/unpack helpers are generated for every message. These
+  // wrap protobuf-c functions with an additional type check. If these are not required,
+  // the library size can be significantly reduced by passing the option
+  // disable_message_helpers. e.g.
+  //  protoc --c_out=disable_message_helpers:outdir foo.proto
+  bool generate_helpers = true;
+
   for (unsigned i = 0; i < options.size(); i++) {
     if (options[i].first == "dllexport_decl") {
       dllexport_decl = options[i].second;
+    } else if (options[i].first == "disable_message_helpers") {
+      generate_helpers = false;
     } else {
       *error = "Unknown generator option: " + options[i].first;
       return false;
@@ -146,7 +155,7 @@ bool CGenerator::Generate(const FileDescriptor* file,
   std::string basename = StripProto(file->name());
   basename.append(".pb-c");
 
-  FileGenerator file_generator(file, dllexport_decl);
+  FileGenerator file_generator(file, dllexport_decl, generate_helpers);
 
   // Generate header.
   {

--- a/protoc-c/c_message.cc
+++ b/protoc-c/c_message.cc
@@ -80,9 +80,11 @@ namespace c {
 // ===================================================================
 
 MessageGenerator::MessageGenerator(const Descriptor* descriptor,
-                                   const std::string& dllexport_decl)
+                                   const std::string& dllexport_decl,
+                                   bool generate_helpers)
   : descriptor_(descriptor),
     dllexport_decl_(dllexport_decl),
+    generate_helpers_(generate_helpers),
     field_generators_(descriptor),
     nested_generators_(new std::unique_ptr<MessageGenerator>[
       descriptor->nested_type_count()]),
@@ -266,7 +268,7 @@ GenerateHelperFunctionDeclarations(io::Printer* printer, bool is_submessage)
 		 "void   $lcclassname$__init\n"
 		 "                     ($classname$         *message);\n"
 		);
-  if (!is_submessage) {
+  if (!is_submessage && generate_helpers_) {
     printer->Print(vars,
 		 "size_t $lcclassname$__get_packed_size\n"
 		 "                     (const $classname$   *message);\n"
@@ -342,7 +344,7 @@ GenerateHelperFunctionDefinitions(io::Printer* printer, bool is_submessage)
 		 "  static const $classname$ init_value = $ucclassname$__INIT;\n"
 		 "  *message = init_value;\n"
 		 "}\n");
-  if (!is_submessage) {
+  if (!is_submessage && generate_helpers_) {
     printer->Print(vars,
 		 "size_t $lcclassname$__get_packed_size\n"
 		 "                     (const $classname$ *message)\n"

--- a/protoc-c/c_message.h
+++ b/protoc-c/c_message.h
@@ -86,7 +86,8 @@ class MessageGenerator {
  public:
   // See generator.cc for the meaning of dllexport_decl.
   explicit MessageGenerator(const Descriptor* descriptor,
-                            const std::string& dllexport_decl);
+                            const std::string& dllexport_decl,
+                            bool generate_helpers = true);
   ~MessageGenerator();
 
   // Header stuff.
@@ -126,6 +127,7 @@ class MessageGenerator {
 
   const Descriptor* descriptor_;
   std::string dllexport_decl_;
+  bool generate_helpers_;
   FieldGeneratorMap field_generators_;
   std::unique_ptr<std::unique_ptr<MessageGenerator>[]> nested_generators_;
   std::unique_ptr<std::unique_ptr<EnumGenerator>[]> enum_generators_;


### PR DESCRIPTION
This prevents the generation of specific helper functions for
get_packed_size, pack, pack_to_buffer, unpack and free_unpacked for each
message type. The generic protobuf_c_message version of these can still
be called. This significantly reduces the size of the generated libraries.

The command to do this looks like:
 protoc --c_out=disable_message_helpers:outdir foo.proto

Signed-off-by: Luuk Paulussen <luuk.paulussen@alliedtelesis.co.nz>