### PR TITLE
Support nan default values.

### DIFF
--- a/protoc-c/c_file.cc
+++ b/protoc-c/c_file.cc
@@ -134,6 +134,7 @@ void FileGenerator::GenerateHeader(io::Printer* printer) {
     "#ifndef PROTOBUF_C_$filename_identifier$__INCLUDED\n"
     "#define PROTOBUF_C_$filename_identifier$__INCLUDED\n"
     "\n"
+    "#include <math.h>\n"
     "#include <protobuf-c/protobuf-c.h>\n"
     "\n"
     "PROTOBUF_C__BEGIN_DECLS\n"

--- a/protoc-c/c_primitive_field.cc
+++ b/protoc-c/c_primitive_field.cc
@@ -60,6 +60,7 @@
 
 // Modified to implement C code by Dave Benson.
 
+#include <cmath>
 #include <protoc-c/c_primitive_field.h>
 #include <protoc-c/c_helpers.h>
 #include <google/protobuf/io/printer.h>
@@ -137,8 +138,14 @@ string PrimitiveFieldGenerator::GetDefaultValue() const
     case FieldDescriptor::CPPTYPE_UINT64:
       return SimpleItoa(descriptor_->default_value_uint64()) + "ull";
     case FieldDescriptor::CPPTYPE_FLOAT:
+      if (std::isnan(descriptor_->default_value_float())) {
+        return "NAN";
+      }
       return SimpleFtoa(descriptor_->default_value_float());
     case FieldDescriptor::CPPTYPE_DOUBLE:
+      if (std::isnan(descriptor_->default_value_double())) {
+        return "NAN";
+      }
       return SimpleDtoa(descriptor_->default_value_double());
     case FieldDescriptor::CPPTYPE_BOOL:
       return descriptor_->default_value_bool() ? "1" : "0";

--- a/t/test-full.proto
+++ b/t/test-full.proto
@@ -216,24 +216,28 @@ message TestMessRequiredMessage {
 message EmptyMess {
 }
 message DefaultRequiredValues {
-  required int32 v_int32   = 1 [default = -42];
-  required uint32 v_uint32 = 2 [default = 666];
-  required int32 v_int64   = 3 [default = 100000];
-  required uint32 v_uint64 = 4 [default = 100001];
-  required float v_float   = 5 [default = 2.5];
-  required double v_double = 6 [default = 4.5];
-  required string v_string = 7 [default = "hi mom\n"];
-  required bytes v_bytes   = 8 [default = "a \0 character"];
+  required int32 v_int32       = 1 [default = -42];
+  required uint32 v_uint32     = 2 [default = 666];
+  required int32 v_int64       = 3 [default = 100000];
+  required uint32 v_uint64     = 4 [default = 100001];
+  required float v_float       = 5 [default = 2.5];
+  required double v_double     = 6 [default = 4.5];
+  required string v_string     = 7 [default = "hi mom\n"];
+  required bytes v_bytes       = 8 [default = "a \0 character"];
+  required float v_float_nan   = 9 [default = nan];
+  required double v_double_nan = 10 [default = nan];
 }
 message DefaultOptionalValues {
-  optional int32 v_int32   = 1 [default = -42];
-  optional uint32 v_uint32 = 2 [default = 666];
-  optional int32 v_int64   = 3 [default = 100000];
-  optional uint32 v_uint64 = 4 [default = 100001];
-  optional float v_float   = 5 [default = 2.5];
-  optional double v_double = 6 [default = 4.5];
-  optional string v_string = 7 [default = "hi mom\n"];
-  optional bytes v_bytes   = 8 [default = "a \0 character"];
+  optional int32 v_int32       = 1 [default = -42];
+  optional uint32 v_uint32     = 2 [default = 666];
+  optional int32 v_int64       = 3 [default = 100000];
+  optional uint32 v_uint64     = 4 [default = 100001];
+  optional float v_float       = 5 [default = 2.5];
+  optional double v_double     = 6 [default = 4.5];
+  optional string v_string     = 7 [default = "hi mom\n"];
+  optional bytes v_bytes       = 8 [default = "a \0 character"];
+  optional float v_float_nan   = 9 [default = nan];
+  optional double v_double_nan = 10 [default = nan];
 }
 message LowerCase {
   enum CaseEnum {


### PR DESCRIPTION
This PR adds support for float/double fields with a default value of `nan`, as the [Protocol Buffers Language Specification](https://developers.google.com/protocol-buffers/docs/reference/proto3-spec) supports `nan`.

I tested this change locally with the following protobuf and main program:

sandbox.proto:
```
syntax = "proto2";
package sandbox;
message PointA {
    optional double x = 1 [default = nan];
}
message PointB {
    required double x = 1 [default = nan];
    optional double y = 2 [default = nan];
}
```

sandbox.cc:
```
#include <sandbox.pb-c.h>
#include <stdio.h>
int main() {
	Sandbox__PointA msg = SANDBOX__POINT_A__INIT;
	printf("hello\n");
	printf("%f\n", msg.x);
	msg.x = 1;
	printf("%f\n", msg.x);
	return 0;
}
```

This code produced the following output:
```
hello
nan
1.000000
```