### PR TITLE
Avoid "unused function parameter" compiler warning

### DIFF
--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -148,12 +148,14 @@ protobuf_c_version_number(void)
 static void *
 system_alloc(void *allocator_data, size_t size)
 {
+	(void)allocator_data;
 	return malloc(size);
 }
 
 static void
 system_free(void *allocator_data, void *data)
 {
+	(void)allocator_data;
 	free(data);
 }
 


### PR DESCRIPTION
Use `_attribute__((__unused__))` for the `allocator_data` parameter of functions `system_alloc` and `system_free`. This allows us to integrate the file into build environments in which the "unused function parameter" warning is active. For example, with gcc 10 this avoids the following warnings:

```
protobuf-c.c: In function ‘system_alloc’:
protobuf-c.c:149:44: error: unused parameter ‘allocator_data’ [-Werror=unused-parameter]
  149 | system_alloc(void *__attribute__((unused)) allocator_data, size_t size)
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
protobuf-c.c: In function ‘system_free’:
protobuf-c.c:155:43: error: unused parameter ‘allocator_data’ [-Werror=unused-parameter]
  155 | system_free(void *__attribute__((unused)) allocator_data, void *data)
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
```