### PR TITLE
Install debug symbols alongside the protobuf-c.lib

### DIFF
--- a/build-cmake/CMakeLists.txt
+++ b/build-cmake/CMakeLists.txt
@@ -37,6 +37,7 @@ SET (PC_SOURCES
         ${MAIN_DIR}/protobuf-c/protobuf-c.h)
 
 ADD_LIBRARY(protobuf-c ${PC_SOURCES})
+set_target_properties(protobuf-c PROPERTIES COMPILE_PDB_NAME protobuf-c)
 
 INCLUDE_DIRECTORIES(${MAIN_DIR})
 INCLUDE_DIRECTORIES(${MAIN_DIR}/protobuf-c)
@@ -136,6 +137,7 @@ ENDIF()
 INSTALL(TARGETS protoc-gen-c protobuf-c RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
 INSTALL(FILES ${MAIN_DIR}/protobuf-c/protobuf-c.h DESTINATION include/protobuf-c)
 INSTALL(FILES ${MAIN_DIR}/protobuf-c/protobuf-c.h DESTINATION include)
+INSTALL(FILES ${CMAKE_BINARY_DIR}/protobuf-c.pdb DESTINATION lib OPTIONAL)
 
 IF(CMAKE_HOST_UNIX)
 INSTALL(CODE "EXECUTE_PROCESS (COMMAND ln -sf protoc-gen-c protoc-c WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin)")


### PR DESCRIPTION
A user of the protobuf-c library is confronted with MSVC warnings about missing
PDB if the library happens to be built/configured using the CMAKE_BUILD_TYPE
"Debug" or "RelWithDebInfo". This commit deals away with the warning by
installing the "protobuf-c.pdb" alongside the lib. The .pdb is installed only
if it exists. Configuring "Release" or building under Linux won't produce and
won't install the PDB.