### PR TITLE
update for Windows shared (dll) build

### DIFF
--- a/protobuf-c/protobuf-c.h
+++ b/protobuf-c/protobuf-c.h
@@ -211,14 +211,14 @@ size_t foo__bar__baz_bah__pack_to_buffer
 
 PROTOBUF_C__BEGIN_DECLS
 
-#if defined(_WIN32) && defined(PROTOBUF_C_USE_SHARED_LIB)
+#if defined(_WIN32) && defined(PROTOBUF_USE_DLLS)
 # ifdef PROTOBUF_C_EXPORT
-#  define PROTOBUF_C__API __declspec(dllexport)
+#  define PROTOC_C_EXPORT __declspec(dllexport)
 # else
-#  define PROTOBUF_C__API __declspec(dllimport)
+#  define PROTOC_C_EXPORT __declspec(dllimport)
 # endif
 #else
-# define PROTOBUF_C__API
+# define PROTOC_C_EXPORT
 #endif
 
 #if !defined(PROTOBUF_C__NO_DEPRECATED) && \
@@ -238,7 +238,7 @@ PROTOBUF_C__BEGIN_DECLS
 #define PROTOBUF_C__ENUM_DESCRIPTOR_MAGIC       0x114315af
 
 /* Empty string used for initializers */
-PROTOBUF_C__API extern const char protobuf_c_empty_string[];
+PROTOC_C_EXPORT extern const char protobuf_c_empty_string[];
 
 /**
  * \defgroup api Public API
@@ -771,7 +771,7 @@ struct ProtobufCServiceDescriptor {
  *
  * \return A string containing the version number of protobuf-c.
  */
-PROTOBUF_C__API
+PROTOC_C_EXPORT
 const char *
 protobuf_c_version(void);
 
@@ -782,7 +782,7 @@ protobuf_c_version(void);
  * \return A 32 bit unsigned integer containing the version number of
  *      protobuf-c, represented in base-10 as (MAJOR*1E6) + (MINOR*1E3) + PATCH.
  */
-PROTOBUF_C__API
+PROTOC_C_EXPORT
 uint32_t
 protobuf_c_version_number(void);
 
@@ -817,7 +817,7 @@ protobuf_c_version_number(void);
  * \retval NULL
  *      If not found or if the optimize_for = CODE_SIZE option was set.
  */
-PROTOBUF_C__API
+PROTOC_C_EXPORT
 const ProtobufCEnumValue *
 protobuf_c_enum_descriptor_get_value_by_name(
 	const ProtobufCEnumDescriptor *desc,
@@ -838,7 +838,7 @@ protobuf_c_enum_descriptor_get_value_by_name(
  * \retval NULL
  *      If not found.
  */
-PROTOBUF_C__API
+PROTOC_C_EXPORT
 const ProtobufCEnumValue *
 protobuf_c_enum_descriptor_get_value(
 	const ProtobufCEnumDescriptor *desc,
@@ -857,7 +857,7 @@ protobuf_c_enum_descriptor_get_value(
  * \retval NULL
  *      If not found or if the optimize_for = CODE_SIZE option was set.
  */
-PROTOBUF_C__API
+PROTOC_C_EXPORT
 const ProtobufCFieldDescriptor *
 protobuf_c_message_descriptor_get_field_by_name(
 	const ProtobufCMessageDescriptor *desc,
@@ -876,7 +876,7 @@ protobuf_c_message_descriptor_get_field_by_name(
  * \retval NULL
  *      If not found.
  */
-PROTOBUF_C__API
+PROTOC_C_EXPORT
 const ProtobufCFieldDescriptor *
 protobuf_c_message_descriptor_get_field(
 	const ProtobufCMessageDescriptor *desc,
@@ -890,7 +890,7 @@ protobuf_c_message_descriptor_get_field(
  * \return
  *      Number of bytes.
  */
-PROTOBUF_C__API
+PROTOC_C_EXPORT
 size_t
 protobuf_c_message_get_packed_size(const ProtobufCMessage *message);
 
@@ -910,7 +910,7 @@ protobuf_c_message_get_packed_size(const ProtobufCMessage *message);
  * \return
  *      Number of bytes stored in `out`.
  */
-PROTOBUF_C__API
+PROTOC_C_EXPORT
 size_t
 protobuf_c_message_pack(const ProtobufCMessage *message, uint8_t *out);
 
@@ -927,7 +927,7 @@ protobuf_c_message_pack(const ProtobufCMessage *message, uint8_t *out);
  * \return
  *      Number of bytes passed to the virtual buffer.
  */
-PROTOBUF_C__API
+PROTOC_C_EXPORT
 size_t
 protobuf_c_message_pack_to_buffer(
 	const ProtobufCMessage *message,
@@ -950,7 +950,7 @@ protobuf_c_message_pack_to_buffer(
  * \retval NULL
  *      If an error occurred during unpacking.
  */
-PROTOBUF_C__API
+PROTOC_C_EXPORT
 ProtobufCMessage *
 protobuf_c_message_unpack(
 	const ProtobufCMessageDescriptor *descriptor,
@@ -970,7 +970,7 @@ protobuf_c_message_unpack(
  *      `ProtobufCAllocator` to use for memory deallocation. May be NULL to
  *      specify the default allocator.
  */
-PROTOBUF_C__API
+PROTOC_C_EXPORT
 void
 protobuf_c_message_free_unpacked(
 	ProtobufCMessage *message,
@@ -987,7 +987,7 @@ protobuf_c_message_free_unpacked(
  * \retval FALSE
  *      Message is invalid.
  */
-PROTOBUF_C__API
+PROTOC_C_EXPORT
 protobuf_c_boolean
 protobuf_c_message_check(const ProtobufCMessage *);
 
@@ -1002,7 +1002,7 @@ protobuf_c_message_check(const ProtobufCMessage *);
  * \param message
  *      Allocated block of memory of size `descriptor->sizeof_message`.
  */
-PROTOBUF_C__API
+PROTOC_C_EXPORT
 void
 protobuf_c_message_init(
 	const ProtobufCMessageDescriptor *descriptor,
@@ -1014,7 +1014,7 @@ protobuf_c_message_init(
  * \param service
  *      The service object to free.
  */
-PROTOBUF_C__API
+PROTOC_C_EXPORT
 void
 protobuf_c_service_destroy(ProtobufCService *service);
 
@@ -1031,7 +1031,7 @@ protobuf_c_service_destroy(ProtobufCService *service);
  * \retval NULL
  *      If not found or if the optimize_for = CODE_SIZE option was set.
  */
-PROTOBUF_C__API
+PROTOC_C_EXPORT
 const ProtobufCMethodDescriptor *
 protobuf_c_service_descriptor_get_method_by_name(
 	const ProtobufCServiceDescriptor *desc,
@@ -1076,21 +1076,21 @@ do {                                                                    \
  * \param data
  *      Data to append.
  */
-PROTOBUF_C__API
+PROTOC_C_EXPORT
 void
 protobuf_c_buffer_simple_append(
 	ProtobufCBuffer *buffer,
 	size_t len,
 	const unsigned char *data);
 
-PROTOBUF_C__API
+PROTOC_C_EXPORT
 void
 protobuf_c_service_generated_init(
 	ProtobufCService *service,
 	const ProtobufCServiceDescriptor *descriptor,
 	ProtobufCServiceDestroy destroy);
 
-PROTOBUF_C__API
+PROTOC_C_EXPORT
 void
 protobuf_c_service_invoke_internal(
 	ProtobufCService *service,

--- a/protoc-c/c_generator.h
+++ b/protoc-c/c_generator.h
@@ -68,7 +68,7 @@
 #include <string>
 #include <google/protobuf/compiler/code_generator.h>
 
-#if defined(_WIN32) && defined(PROTOBUF_C_USE_SHARED_LIB)
+#if defined(_WIN32) && defined(PROTOBUF_USE_DLLS)
 # ifdef PROTOBUF_C_EXPORT
 #  define PROTOC_C_EXPORT __declspec(dllexport)
 # else


### PR DESCRIPTION
- use `PROTOBUF_USE_DLLS` as this is what is required by recent libprotobuf, for shared (dll) build on Windows
- use `PROTOC_C_EXPORT` in protobuf-c.h as well

(sorry I missed these local changes, in my initial review)