### PR TITLE
Run GitHub actions also on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Test Build
 on:
   push:
+    branches:
+      - master
+      - next
+  pull_request:
   schedule:
     - cron: '0 0 * * 0' # Every Sunday at 00:00
 jobs:


### PR DESCRIPTION
The push trigger didn't seem to work for PRs based in outside repos. So limit the push trigger to master and next and enable a PR trigger.