### PR TITLE
Makefile.am: change link order

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -107,8 +107,8 @@ protoc_c_protoc_gen_c_CXXFLAGS = \
 	$(AM_CXXFLAGS) \
 	$(protobuf_CFLAGS)
 protoc_c_protoc_gen_c_LDADD = \
-	$(protobuf_LIBS) \
-	-lprotoc
+	-lprotoc \
+	$(protobuf_LIBS)
 
 protobuf-c/protobuf-c.pb.cc protobuf-c/protobuf-c.pb.h: @PROTOC@ $(top_srcdir)/protobuf-c/protobuf-c.proto
 	$(AM_V_GEN)@PROTOC@ -I$(top_srcdir) --cpp_out=$(top_builddir) $(top_srcdir)/protobuf-c/protobuf-c.proto


### PR DESCRIPTION
protoc depends on protobuf libraries for execution. Order libraries
accordingly. Observing link errors with yocto's meta-mingw project
during static linkage.

Signed-off-by: Sinan Kaya <sinan.kaya@microsoft.com>