### PR TITLE
Add generator parameter --c_opt=disable_lowercase_name to use original type name

### DIFF
--- a/protoc-c/c_enum.cc
+++ b/protoc-c/c_enum.cc
@@ -72,10 +72,8 @@ namespace protobuf {
 namespace compiler {
 namespace c {
 
-EnumGenerator::EnumGenerator(const EnumDescriptor* descriptor,
-                             const std::string& dllexport_decl)
-  : descriptor_(descriptor),
-    dllexport_decl_(dllexport_decl) {
+EnumGenerator::EnumGenerator(const EnumDescriptor* descriptor)
+  : descriptor_(descriptor) {
 }
 
 EnumGenerator::~EnumGenerator() {}
@@ -127,10 +125,11 @@ void EnumGenerator::GenerateDefinition(io::Printer* printer) {
 
 void EnumGenerator::GenerateDescriptorDeclarations(io::Printer* printer) {
   std::map<std::string, std::string> vars;
-  if (dllexport_decl_.empty()) {
+  auto it = g_generator_options.find("dllexport_decl");
+  if (it == g_generator_options.end()) {
     vars["dllexport"] = "";
   } else {
-    vars["dllexport"] = dllexport_decl_ + " ";
+    vars["dllexport"] = it->second + " ";
   }
   vars["classname"] = FullNameToC(descriptor_->full_name(), descriptor_->file());
   vars["lcclassname"] = FullNameToLower(descriptor_->full_name(), descriptor_->file());

--- a/protoc-c/c_extension.cc
+++ b/protoc-c/c_extension.cc
@@ -62,6 +62,7 @@
 
 #include <protoc-c/c_extension.h>
 #include <protoc-c/c_helpers.h>
+#include <protoc-c/options.h>
 #include <google/protobuf/io/printer.h>
 
 namespace google {
@@ -69,10 +70,8 @@ namespace protobuf {
 namespace compiler {
 namespace c {
 
-ExtensionGenerator::ExtensionGenerator(const FieldDescriptor* descriptor,
-                                       const std::string& dllexport_decl)
-  : descriptor_(descriptor),
-    dllexport_decl_(dllexport_decl) {
+ExtensionGenerator::ExtensionGenerator(const FieldDescriptor* descriptor)
+  : descriptor_(descriptor) {
 }
 
 ExtensionGenerator::~ExtensionGenerator() {}

--- a/protoc-c/c_extension.h
+++ b/protoc-c/c_extension.h
@@ -65,6 +65,7 @@
 
 #include <string>
 #include <google/protobuf/stubs/common.h>
+#include <protoc-c/options.h>
 
 namespace google {
 namespace protobuf {
@@ -83,9 +84,8 @@ namespace c {
 // since extensions are just simple identifiers with interesting types.
 class ExtensionGenerator {
  public:
-  // See generator.cc for the meaning of dllexport_decl.
-  explicit ExtensionGenerator(const FieldDescriptor* descriptor,
-                              const std::string& dllexport_decl);
+  explicit ExtensionGenerator(const FieldDescriptor* descriptor);
+
   ~ExtensionGenerator();
 
   // Header stuff.
@@ -97,7 +97,6 @@ class ExtensionGenerator {
  private:
   const FieldDescriptor* descriptor_;
   std::string type_traits_;
-  std::string dllexport_decl_;
 
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ExtensionGenerator);
 };

--- a/protoc-c/c_file.cc
+++ b/protoc-c/c_file.cc
@@ -79,8 +79,7 @@ namespace c {
 
 // ===================================================================
 
-FileGenerator::FileGenerator(const FileDescriptor* file,
-                             const std::string& dllexport_decl)
+FileGenerator::FileGenerator(const FileDescriptor* file)
   : file_(file),
     message_generators_(
       new std::unique_ptr<MessageGenerator>[file->message_type_count()]),
@@ -93,22 +92,22 @@ FileGenerator::FileGenerator(const FileDescriptor* file,
 
   for (int i = 0; i < file->message_type_count(); i++) {
     message_generators_[i].reset(
-      new MessageGenerator(file->message_type(i), dllexport_decl));
+      new MessageGenerator(file->message_type(i)));
   }
 
   for (int i = 0; i < file->enum_type_count(); i++) {
     enum_generators_[i].reset(
-      new EnumGenerator(file->enum_type(i), dllexport_decl));
+      new EnumGenerator(file->enum_type(i)));
   }
 
   for (int i = 0; i < file->service_count(); i++) {
     service_generators_[i].reset(
-      new ServiceGenerator(file->service(i), dllexport_decl));
+      new ServiceGenerator(file->service(i)));
   }
 
   for (int i = 0; i < file->extension_count(); i++) {
     extension_generators_[i].reset(
-      new ExtensionGenerator(file->extension(i), dllexport_decl));
+      new ExtensionGenerator(file->extension(i)));
   }
 }
 

--- a/protoc-c/c_file.h
+++ b/protoc-c/c_file.h
@@ -68,6 +68,7 @@
 #include <vector>
 #include <google/protobuf/stubs/common.h>
 #include <protoc-c/c_field.h>
+#include <protoc-c/options.h>
 
 namespace google {
 namespace protobuf {
@@ -88,9 +89,8 @@ class ExtensionGenerator;      // extension.h
 
 class FileGenerator {
  public:
-  // See generator.cc for the meaning of dllexport_decl.
-  explicit FileGenerator(const FileDescriptor* file,
-                         const std::string& dllexport_decl);
+  explicit FileGenerator(const FileDescriptor* file);
+
   ~FileGenerator();
 
   void GenerateHeader(io::Printer* printer);

--- a/protoc-c/c_generator.cc
+++ b/protoc-c/c_generator.cc
@@ -61,6 +61,7 @@
 // Modified to implement C code by Dave Benson.
 
 #include <protoc-c/c_generator.h>
+#include <protoc-c/options.h>
 
 #include <memory>
 #include <vector>
@@ -71,31 +72,30 @@
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/io/zero_copy_stream.h>
 #include <protobuf-c/protobuf-c.pb.h>
+#include <protoc-c/options.h>
 
 namespace google {
 namespace protobuf {
 namespace compiler {
 namespace c {
 
+GeneratorOptions g_generator_options;
+
 // Parses a set of comma-delimited name/value pairs, e.g.:
 //   "foo=bar,baz,qux=corge"
 // parses to the pairs:
 //   ("foo", "bar"), ("baz", ""), ("qux", "corge")
-void ParseOptions(const std::string& text, std::vector<std::pair<std::string, std::string> >* output) {
+void ParseOptions(const std::string& text, GeneratorOptions& output) {
   std::vector<std::string> parts;
   SplitStringUsing(text, ",", &parts);
 
   for (unsigned i = 0; i < parts.size(); i++) {
     std::string::size_type equals_pos = parts[i].find_first_of('=');
-    std::pair<std::string, std::string> value;
     if (equals_pos == std::string::npos) {
-      value.first = parts[i];
-      value.second = "";
+      output[parts[i]] = "";
     } else {
-      value.first = parts[i].substr(0, equals_pos);
-      value.second = parts[i].substr(equals_pos + 1);
+      output[parts[i].substr(0, equals_pos)] = parts[i].substr(equals_pos + 1);
     }
-    output->push_back(value);
   }
 }
 
@@ -109,47 +109,37 @@ bool CGenerator::Generate(const FileDescriptor* file,
   if (file->options().GetExtension(pb_c_file).no_generate())
     return true;
 
-  std::vector<std::pair<std::string, std::string> > options;
-  ParseOptions(parameter, &options);
-
-  // -----------------------------------------------------------------
   // parse generator options
+  ParseOptions(parameter, g_generator_options);
 
-  // TODO(kenton):  If we ever have more options, we may want to create a
-  //   class that encapsulates them which we can pass down to all the
-  //   generator classes.  Currently we pass dllexport_decl down to all of
-  //   them via the constructors, but we don't want to have to add another
-  //   constructor parameter for every option.
-
+  // For option --c_opt=dllexport_decl=FOO_EXPORT:
   // If the dllexport_decl option is passed to the compiler, we need to write
   // it in front of every symbol that should be exported if this .proto is
   // compiled into a Windows DLL.  E.g., if the user invokes the protocol
   // compiler as:
-  //   protoc --cpp_out=dllexport_decl=FOO_EXPORT:outdir foo.proto
+  //   protoc-c --c_opt=outdir --c_opt=dllexport_decl=FOO_EXPORT foo.proto
   // then we'll define classes like this:
-  //   class FOO_EXPORT Foo {
+  //   struct FOO_EXPORT Foo {
   //     ...
   //   }
   // FOO_EXPORT is a macro which should expand to __declspec(dllexport) or
   // __declspec(dllimport) depending on what is being compiled.
-  std::string dllexport_decl;
+  //
+  // for option --c_opt=disable_lowercase_name:
+  // Identifier case will remain the same.
 
-  for (unsigned i = 0; i < options.size(); i++) {
-    if (options[i].first == "dllexport_decl") {
-      dllexport_decl = options[i].second;
-    } else {
-      *error = "Unknown generator option: " + options[i].first;
+  for (auto &it : g_generator_options) {
+    if (it.first != "dllexport_decl" &&
+        it.first != "disable_lowercase_name") {
+      *error = "Unknown generator option: " + it.first;
       return false;
     }
   }
 
-  // -----------------------------------------------------------------
-
-
   std::string basename = StripProto(file->name());
   basename.append(".pb-c");
 
-  FileGenerator file_generator(file, dllexport_decl);
+  FileGenerator file_generator(file);
 
   // Generate header.
   {

--- a/protoc-c/c_helpers.cc
+++ b/protoc-c/c_helpers.cc
@@ -295,7 +295,12 @@ std::set<std::string> MakeKeywordsMap() {
 std::set<std::string> kKeywords = MakeKeywordsMap();
 
 std::string FieldName(const FieldDescriptor* field) {
-  std::string result = ToLower(field->name());
+  std::string result;
+  if (g_generator_options.find("disable_lowercase_name") == g_generator_options.end()) {
+    result = ToLower(field->name());
+  } else {
+    result = field->name();
+  }
   if (kKeywords.count(result) > 0) {
     result.append("_");
   }

--- a/protoc-c/c_helpers.h
+++ b/protoc-c/c_helpers.h
@@ -69,6 +69,7 @@
 #include <google/protobuf/descriptor.h>
 #include <protobuf-c/protobuf-c.pb.h>
 #include <google/protobuf/io/printer.h>
+#include <protoc-c/options.h>
 
 namespace google {
 namespace protobuf {

--- a/protoc-c/c_message.h
+++ b/protoc-c/c_message.h
@@ -67,6 +67,7 @@
 #include <string>
 #include <google/protobuf/stubs/common.h>
 #include <protoc-c/c_field.h>
+#include <protoc-c/options.h>
 
 namespace google {
 namespace protobuf {
@@ -84,9 +85,8 @@ class ExtensionGenerator;      // extension.h
 
 class MessageGenerator {
  public:
-  // See generator.cc for the meaning of dllexport_decl.
-  explicit MessageGenerator(const Descriptor* descriptor,
-                            const std::string& dllexport_decl);
+  explicit MessageGenerator(const Descriptor* descriptor);
+
   ~MessageGenerator();
 
   // Header stuff.
@@ -131,7 +131,6 @@ class MessageGenerator {
   std::string GetDefaultValueC(const FieldDescriptor *fd);
 
   const Descriptor* descriptor_;
-  std::string dllexport_decl_;
   FieldGeneratorMap field_generators_;
   std::unique_ptr<std::unique_ptr<MessageGenerator>[]> nested_generators_;
   std::unique_ptr<std::unique_ptr<EnumGenerator>[]> enum_generators_;

--- a/protoc-c/c_service.cc
+++ b/protoc-c/c_service.cc
@@ -69,8 +69,7 @@ namespace protobuf {
 namespace compiler {
 namespace c {
 
-ServiceGenerator::ServiceGenerator(const ServiceDescriptor* descriptor,
-                                   const std::string& dllexport_decl)
+ServiceGenerator::ServiceGenerator(const ServiceDescriptor* descriptor)
   : descriptor_(descriptor) {
   vars_["name"] = descriptor_->name();
   vars_["fullname"] = descriptor_->full_name();
@@ -79,10 +78,11 @@ ServiceGenerator::ServiceGenerator(const ServiceDescriptor* descriptor,
   vars_["ucfullname"] = FullNameToUpper(descriptor_->full_name(), descriptor_->file());
   vars_["lcfullpadd"] = ConvertToSpaces(vars_["lcfullname"]);
   vars_["package"] = descriptor_->file()->package();
-  if (dllexport_decl.empty()) {
+  auto it = g_generator_options.find("dllexport_decl");
+  if (it == g_generator_options.end()) {
     vars_["dllexport"] = "";
   } else {
-    vars_["dllexport"] = dllexport_decl + " ";
+    vars_["dllexport"] = it->second + " ";
   }
 }
 

--- a/protoc-c/c_service.h
+++ b/protoc-c/c_service.h
@@ -66,6 +66,7 @@
 #include <map>
 #include <string>
 #include <google/protobuf/descriptor.h>
+#include <protoc-c/options.h>
 
 namespace google {
 namespace protobuf {
@@ -80,9 +81,8 @@ namespace c {
 
 class ServiceGenerator {
  public:
-  // See generator.cc for the meaning of dllexport_decl.
-  explicit ServiceGenerator(const ServiceDescriptor* descriptor,
-                            const std::string& dllexport_decl);
+  explicit ServiceGenerator(const ServiceDescriptor* descriptor);
+
   ~ServiceGenerator();
 
   // Header stuff.

--- a/protoc-c/main.cc
+++ b/protoc-c/main.cc
@@ -13,7 +13,7 @@ int main(int argc, char* argv[]) {
 
   if (invocation_basename == legacy_name) {
     google::protobuf::compiler::CommandLineInterface cli;
-    cli.RegisterGenerator("--c_out", &c_generator, "Generate C/H files.");
+    cli.RegisterGenerator("--c_out", "--c_opt", &c_generator, "Generate C/H files.");
     cli.SetVersionInfo(PACKAGE_STRING);
     return cli.Run(argc, argv);
   }

--- a/protoc-c/options.h
+++ b/protoc-c/options.h
@@ -60,58 +60,23 @@
 
 // Modified to implement C code by Dave Benson.
 
-#ifndef GOOGLE_PROTOBUF_COMPILER_C_ENUM_H__
-#define GOOGLE_PROTOBUF_COMPILER_C_ENUM_H__
+#ifndef GOOGLE_PROTOBUF_COMPILER_C_OPTIONS_H__
+#define GOOGLE_PROTOBUF_COMPILER_C_OPTIONS_H__
 
-#include <string>
-#include <google/protobuf/descriptor.h>
-#include <protoc-c/options.h>
+#include <map>
 
 namespace google {
-namespace protobuf {
-  namespace io {
-    class Printer;             // printer.h
-  }
-}
-
 namespace protobuf {
 namespace compiler {
 namespace c {
 
-class EnumGenerator {
- public:
-  explicit EnumGenerator(const EnumDescriptor* descriptor);
+typedef std::map<std::string, std::string> GeneratorOptions;
 
-  ~EnumGenerator();
-
-  // Header stuff.
-
-  // Generate header code defining the enum.  This code should be placed
-  // within the enum's package namespace, but NOT within any class, even for
-  // nested enums.
-  void GenerateDefinition(io::Printer* printer);
-
-  void GenerateDescriptorDeclarations(io::Printer* printer);
-
-
-  // Source file stuff.
-
-  // Generate the ProtobufCEnumDescriptor for this enum
-  void GenerateEnumDescriptor(io::Printer* printer);
-
-  // Generate static initializer for a ProtobufCEnumValue
-  // given the index of the value in the enum.
-  void GenerateValueInitializer(io::Printer *printer, int index);
-
- private:
-  const EnumDescriptor* descriptor_;
-
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(EnumGenerator);
-};
+extern GeneratorOptions g_generator_options;
 
 }  // namespace c
 }  // namespace compiler
 }  // namespace protobuf
-
 }  // namespace google
-#endif  // GOOGLE_PROTOBUF_COMPILER_C_ENUM_H__
+
+#endif  // GOOGLE_PROTOBUF_COMPILER_C_OPTIONS_H__


### PR DESCRIPTION
1. Add a global map to save custom parameters.
2. Add option disable_lowercase_name to use the original type name instead of the C style name.