### PR TITLE
Fix codesmell "or with 0" in generated flags

### DIFF
--- a/protoc-c/c_field.cc
+++ b/protoc-c/c_field.cc
@@ -159,6 +159,11 @@ void FieldGenerator::GenerateDescriptorInitializerGeneric(io::Printer* printer,
   if (oneof != NULL)
     variables["flags"] += " | PROTOBUF_C_FIELD_FLAG_ONEOF";
 
+  // Eliminate codesmell "or with 0"
+  if (variables["flags"].find("0 |") != std::string::npos) {
+   variables["flags"].erase(0, 4);
+  }
+
   printer->Print("{\n");
   if (descriptor_->file()->options().has_optimize_for() &&
         descriptor_->file()->options().optimize_for() ==


### PR DESCRIPTION
New versions of cppcheck are complaining loudly (and rightfully) about the use of patterns like:
```
0 | PROTOBUF_C_FIELD_FLAG_ONEOF
```

This PR specifically removes those cases after the concatenation of the various strings which seemed like the minimal intrusive solution (rather than trying to avoid creating them in the first place).

Signed-off-by: Daniel Egger <daniel@eggers-club.de>