### PR TITLE
GitHub actions fail on Windows due to missing unzip command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
         run: |
           cd ~
           C:\msys64\usr\bin\wget.exe https://github.com/protocolbuffers/protobuf/releases/download/v${{ env.PROTOBUF_VERSION }}/protobuf-cpp-${{ env.PROTOBUF_VERSION }}.zip
-          C:\msys64\usr\bin\unzip protobuf-cpp-${{ env.PROTOBUF_VERSION }}.zip
+          7z x protobuf-cpp-${{ env.PROTOBUF_VERSION }}.zip
           cd ~/protobuf-${{ env.PROTOBUF_VERSION }}/cmake && mkdir build && cd build
           cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=~/protobuf-bin -Dprotobuf_BUILD_SHARED_LIBS=${{ matrix.shared-lib }} ..
           nmake


### PR DESCRIPTION
Windows builds fail on GitHub due to missing unzip:

https://github.com/protobuf-c/protobuf-c/actions/runs/3120315250/jobs/5060804075

7zip is [installed on the GitHub runners](https://github.com/actions/runner-images/blob/main/images/win/Windows2019-Readme.md#tools) and can be used instead.