### PR TITLE
Pass link flags in correct order for static build to work

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -107,8 +107,8 @@ protoc_c_protoc_gen_c_CXXFLAGS = \
 	$(AM_CXXFLAGS) \
 	$(protobuf_CFLAGS)
 protoc_c_protoc_gen_c_LDADD = \
-	$(protobuf_LIBS) \
-	-lprotoc
+	-lprotoc \
+	$(protobuf_LIBS)
 
 protobuf-c/protobuf-c.pb.cc protobuf-c/protobuf-c.pb.h: @PROTOC@ $(top_srcdir)/protobuf-c/protobuf-c.proto
 	$(AM_V_GEN)@PROTOC@ -I$(top_srcdir) --cpp_out=$(top_builddir) $(top_srcdir)/protobuf-c/protobuf-c.proto


### PR DESCRIPTION
Since -lprotoc depends on symbols in -lprotobuf, -lprotobuf must be later on command line invocation. Does not matter for dynamic linking, since dynamic libraries keep track of their dependencies on their own.

Closes: #533