### PR TITLE
Avoid "unused variable" compiler warning

### DIFF
--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -1923,6 +1923,7 @@ repeated_field_pack_to_buffer(const ProtobufCFieldDescriptor *field,
 		buffer->append(buffer, rv, scratch);
 		tmp = pack_buffer_packed_payload(field, count, array, buffer);
 		assert(tmp == payload_len);
+		(void)tmp;
 		return rv + payload_len;
 	} else {
 		size_t siz;


### PR DESCRIPTION
```
clang --version
Apple clang version 14.0.0 (clang-1400.0.29.102)
Target: x86_64-apple-darwin21.6.0


cd protobuf-c && clang -Wall -DNDEBUG -c protobuf-c.c -o protobuf.o
protobuf-c.c:1921:10: warning: variable 'tmp' set but not used [-Wunused-but-set-variable]
                size_t tmp;
                       ^
1 warning generated.
```

I based my change off of the commit in #453 to try to match the style of the repo, but a `#ifdef NDEBUG` could be used instead.