### PR TITLE
Support protobuf 4.22.x

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,7 @@ AM_CPPFLAGS = \
 	-I${top_builddir} \
 	-I${top_srcdir}
 AM_CFLAGS = ${my_CFLAGS}
-AM_LDFLAGS =
+AM_LDFLAGS = ${ABSL_LOG_INTERNAL_CHECK_OP_LIBS} ${ABSL_LOG_RAW_HASH_SET_LIBS}
 
 # code coverage
 

--- a/configure.ac
+++ b/configure.ac
@@ -78,6 +78,14 @@ if test "x$enable_protoc" != "xno"; then
 
   AX_CXX_COMPILE_STDCXX(11, noext, mandatory)
 
+# now checking 4.22.x protobuf, if so, set cxx as 14
+  AS_IF([pkg-config --atleast-version 4.22.0 protobuf],[AX_CXX_COMPILE_STDCXX(14, noext, mandatory)])
+
+  AS_IF([pkg-config --atleast-version 4.22.0 protobuf],
+    [PKG_CHECK_MODULES([ABSL_LOG_INTERNAL_CHECK_OP], [absl_log_internal_check_op],
+       [PKG_CHECK_MODULES([ABSL_LOG_RAW_HASH_SET], [absl_raw_hash_set], [], [AC_MSG_ERROR([Missing absl_raw_hash_set library.])])],
+       [AC_MSG_ERROR([Missing absl_log_internal_check_op library.])])])
+
   PKG_CHECK_MODULES([protobuf], [protobuf >= 3.0.0],
     [proto3_supported=yes],
     [PKG_CHECK_MODULES([protobuf], [protobuf >= 2.6.0])]

--- a/configure.ac
+++ b/configure.ac
@@ -78,8 +78,8 @@ if test "x$enable_protoc" != "xno"; then
 
   AX_CXX_COMPILE_STDCXX(11, noext, mandatory)
 
-# now checking 4.22.x protobuf, if so, set cxx as 14
-  AS_IF([pkg-config --atleast-version 4.22.0 protobuf],[AX_CXX_COMPILE_STDCXX(14, noext, mandatory)])
+# now checking 4.22.x protobuf, if so, set cxx as 17
+  AS_IF([pkg-config --atleast-version 4.22.0 protobuf],[AX_CXX_COMPILE_STDCXX(17, noext, mandatory)])
 
   AS_IF([pkg-config --atleast-version 4.22.0 protobuf],
     [PKG_CHECK_MODULES([ABSL_LOG_INTERNAL_CHECK_OP], [absl_log_internal_check_op],

--- a/protoc-c/c_bytes_field.h
+++ b/protoc-c/c_bytes_field.h
@@ -88,7 +88,6 @@ class BytesFieldGenerator : public FieldGenerator {
  private:
   std::map<std::string, std::string> variables_;
 
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(BytesFieldGenerator);
 };
 
 

--- a/protoc-c/c_enum.h
+++ b/protoc-c/c_enum.h
@@ -107,7 +107,6 @@ class EnumGenerator {
   const EnumDescriptor* descriptor_;
   std::string dllexport_decl_;
 
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(EnumGenerator);
 };
 
 }  // namespace c

--- a/protoc-c/c_enum_field.h
+++ b/protoc-c/c_enum_field.h
@@ -86,7 +86,6 @@ class EnumFieldGenerator : public FieldGenerator {
  private:
   std::map<std::string, std::string> variables_;
 
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(EnumFieldGenerator);
 };
 
 

--- a/protoc-c/c_extension.h
+++ b/protoc-c/c_extension.h
@@ -99,7 +99,6 @@ class ExtensionGenerator {
   std::string type_traits_;
   std::string dllexport_decl_;
 
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ExtensionGenerator);
 };
 
 }  // namespace c

--- a/protoc-c/c_field.cc
+++ b/protoc-c/c_field.cc
@@ -231,7 +231,7 @@ FieldGeneratorMap::~FieldGeneratorMap() {}
 
 const FieldGenerator& FieldGeneratorMap::get(
     const FieldDescriptor* field) const {
-  GOOGLE_CHECK_EQ(field->containing_type(), descriptor_);
+  ABSL_CHECK_EQ(field->containing_type(), descriptor_);
   return *field_generators_[field->index()];
 }
 

--- a/protoc-c/c_field.h
+++ b/protoc-c/c_field.h
@@ -104,8 +104,6 @@ class FieldGenerator {
                                             const std::string &descriptor_addr) const;
   const FieldDescriptor *descriptor_;
 
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(FieldGenerator);
 };
 
 // Convenience class which constructs FieldGenerators for a Descriptor.
@@ -122,7 +120,6 @@ class FieldGeneratorMap {
 
   static FieldGenerator* MakeGenerator(const FieldDescriptor* field);
 
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(FieldGeneratorMap);
 };
 
 }  // namespace c

--- a/protoc-c/c_file.cc
+++ b/protoc-c/c_file.cc
@@ -119,7 +119,7 @@ void FileGenerator::GenerateHeader(io::Printer* printer) {
 
   int min_header_version = 1000000;
 #if defined(HAVE_PROTO3)
-  if (file_->syntax() == FileDescriptor::SYNTAX_PROTO3) {
+  if (FileDescriptorLegacy(file_).syntax() == FileDescriptorLegacy::SYNTAX_PROTO3) {
     min_header_version = 1003000;
   }
 #endif

--- a/protoc-c/c_file.h
+++ b/protoc-c/c_file.h
@@ -104,7 +104,6 @@ class FileGenerator {
   std::unique_ptr<std::unique_ptr<ServiceGenerator>[]> service_generators_;
   std::unique_ptr<std::unique_ptr<ExtensionGenerator>[]> extension_generators_;
 
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(FileGenerator);
 };
 
 }  // namespace c

--- a/protoc-c/c_generator.h
+++ b/protoc-c/c_generator.h
@@ -94,8 +94,6 @@ class PROTOC_C_EXPORT CGenerator : public CodeGenerator {
                 OutputDirectory* output_directory,
                 std::string* error) const;
 
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(CGenerator);
 };
 
 }  // namespace c

--- a/protoc-c/c_helpers.cc
+++ b/protoc-c/c_helpers.cc
@@ -286,7 +286,7 @@ const char* const kKeywordList[] = {
 
 std::set<std::string> MakeKeywordsMap() {
   std::set<std::string> result;
-  for (int i = 0; i < GOOGLE_ARRAYSIZE(kKeywordList); i++) {
+  for (int i = 0; i < ABSL_ARRAYSIZE(kKeywordList); i++) {
     result.insert(kKeywordList[i]);
   }
   return result;
@@ -548,7 +548,7 @@ std::string CEscape(const std::string& src) {
   std::unique_ptr<char[]> dest(new char[dest_length]);
   const int len = CEscapeInternal(src.data(), src.size(),
                                   dest.get(), dest_length, false);
-  GOOGLE_DCHECK_GE(len, 0);
+  ABSL_DCHECK_GE(len, 0);
   return std::string(dest.get(), len);
 }
 

--- a/protoc-c/c_helpers.h
+++ b/protoc-c/c_helpers.h
@@ -67,6 +67,7 @@
 #include <vector>
 #include <sstream>
 #include <google/protobuf/descriptor.h>
+#include <google/protobuf/descriptor_legacy.h>
 #include <protobuf-c/protobuf-c.pb.h>
 #include <google/protobuf/io/printer.h>
 
@@ -172,7 +173,7 @@ int compare_name_indices_by_name(const void*, const void*);
 // This wrapper is needed to be able to compile against protobuf2.
 inline int FieldSyntax(const FieldDescriptor* field) {
 #ifdef HAVE_PROTO3
-  return field->file()->syntax() == FileDescriptor::SYNTAX_PROTO3 ? 3 : 2;
+  return FileDescriptorLegacy(field->file()).syntax() == FileDescriptorLegacy::SYNTAX_PROTO3 ? 3 : 2;
 #else
   return 2;
 #endif

--- a/protoc-c/c_message.cc
+++ b/protoc-c/c_message.cc
@@ -499,7 +499,7 @@ GenerateMessageDescriptor(io::Printer* printer, bool gen_init) {
 	  // NOTE: not supported by protobuf
 	  vars["maybe_static"] = "";
 	  vars["field_dv_ctype"] = "{ ... }";
-	  GOOGLE_LOG(DFATAL) << "Messages can't have default values!";
+	  ABSL_LOG(FATAL) << "Messages can't have default values!";
 	  break;
 	case FieldDescriptor::CPPTYPE_STRING:
 	  if (fd->type() == FieldDescriptor::TYPE_BYTES || opt.string_as_bytes())
@@ -521,7 +521,7 @@ GenerateMessageDescriptor(io::Printer* printer, bool gen_init) {
 	    break;
 	  }
 	default:
-	  GOOGLE_LOG(DFATAL) << "Unknown CPPTYPE";
+	  ABSL_LOG(FATAL) << "Unknown CPPTYPE";
 	  break;
 	}
 	if (!already_defined)

--- a/protoc-c/c_message.h
+++ b/protoc-c/c_message.h
@@ -137,7 +137,6 @@ class MessageGenerator {
   std::unique_ptr<std::unique_ptr<EnumGenerator>[]> enum_generators_;
   std::unique_ptr<std::unique_ptr<ExtensionGenerator>[]> extension_generators_;
 
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(MessageGenerator);
 };
 
 }  // namespace c

--- a/protoc-c/c_message_field.h
+++ b/protoc-c/c_message_field.h
@@ -83,9 +83,6 @@ class MessageFieldGenerator : public FieldGenerator {
   std::string GetDefaultValue(void) const;
   void GenerateStaticInit(io::Printer* printer) const;
 
- private:
-
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(MessageFieldGenerator);
 };
 
 

--- a/protoc-c/c_primitive_field.cc
+++ b/protoc-c/c_primitive_field.cc
@@ -99,7 +99,7 @@ void PrimitiveFieldGenerator::GenerateStructMembers(io::Printer* printer) const
     case FieldDescriptor::TYPE_STRING  :
     case FieldDescriptor::TYPE_BYTES   :
     case FieldDescriptor::TYPE_GROUP   :
-    case FieldDescriptor::TYPE_MESSAGE : GOOGLE_LOG(FATAL) << "not a primitive type"; break;
+    case FieldDescriptor::TYPE_MESSAGE : ABSL_LOG(FATAL) << "not a primitive type"; break;
 
     // No default because we want the compiler to complain if any new
     // types are added.
@@ -143,7 +143,7 @@ std::string PrimitiveFieldGenerator::GetDefaultValue() const
     case FieldDescriptor::CPPTYPE_BOOL:
       return descriptor_->default_value_bool() ? "1" : "0";
     default:
-      GOOGLE_LOG(DFATAL) << "unexpected CPPTYPE in c_primitive_field";
+      ABSL_LOG(FATAL) << "unexpected CPPTYPE in c_primitive_field";
       return "UNEXPECTED_CPPTYPE";
   }
 }
@@ -197,7 +197,7 @@ void PrimitiveFieldGenerator::GenerateDescriptorInitializer(io::Printer* printer
     case FieldDescriptor::TYPE_STRING  :
     case FieldDescriptor::TYPE_BYTES   :
     case FieldDescriptor::TYPE_GROUP   :
-    case FieldDescriptor::TYPE_MESSAGE : GOOGLE_LOG(FATAL) << "not a primitive type"; break;
+    case FieldDescriptor::TYPE_MESSAGE : ABSL_LOG(FATAL) << "not a primitive type"; break;
 
     // No default because we want the compiler to complain if any new
     // types are added.

--- a/protoc-c/c_primitive_field.h
+++ b/protoc-c/c_primitive_field.h
@@ -83,9 +83,6 @@ class PrimitiveFieldGenerator : public FieldGenerator {
   std::string GetDefaultValue(void) const;
   void GenerateStaticInit(io::Printer* printer) const;
 
- private:
-
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(PrimitiveFieldGenerator);
 };
 
 }  // namespace c

--- a/protoc-c/c_service.h
+++ b/protoc-c/c_service.h
@@ -101,7 +101,6 @@ class ServiceGenerator {
   const ServiceDescriptor* descriptor_;
   std::map<std::string, std::string> vars_;
 
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ServiceGenerator);
 };
 
 }  // namespace c

--- a/protoc-c/c_string_field.h
+++ b/protoc-c/c_string_field.h
@@ -88,7 +88,6 @@ class StringFieldGenerator : public FieldGenerator {
  private:
   std::map<std::string, std::string> variables_;
 
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(StringFieldGenerator);
 };
 
 


### PR DESCRIPTION
This builds on https://github.com/protobuf-c/protobuf-c/commit/66a0b0d205224f63f19dd8f96abf9dcdc2112331 from https://github.com/protobuf-c/protobuf-c/pull/548 by:

* https://github.com/protobuf-c/protobuf-c/commit/7706c95d4835e75f182ab56d9dad5c8cd8517e0a: specifying cxx17 instead of cxx14 (needed on my macOS system)
* https://github.com/protobuf-c/protobuf-c/commit/66574f3fd85a205eb7c90b790477d5415364209e: use FileDescriptorLegacy for the deprecated `syntax()` method (see https://github.com/protocolbuffers/protobuf/commit/9bbea4aa65bdaf5fc6c2583e045c07ff37ffb0e7)