### PR TITLE
Silence some compiler diagnostics

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,10 +38,6 @@ my_CFLAGS="\
 -Wstrict-prototypes \
 -Wtype-limits \
 "
-#AX_CHECK_COMPILE_FLAG(["-Wc90-c99-compat"],
-#                      [my_CFLAGS="$my_CFLAGS -Wc90-c99-compat"])
-AX_CHECK_COMPILE_FLAG(["-Wc99-c11-compat"],
-                      [my_CFLAGS="$my_CFLAGS -Wc99-c11-compat"])
 AX_CHECK_COMPILE_FLAG(["-Werror=incompatible-pointer-types"],
                       [my_CFLAGS="$my_CFLAGS -Werror=incompatible-pointer-types"])
 AX_CHECK_COMPILE_FLAG(["-Werror=int-conversion"],

--- a/t/generated-code2/test-generated-code2.c
+++ b/t/generated-code2/test-generated-code2.c
@@ -5,6 +5,9 @@
 #include "t/test-optimized.pb-c.h"
 #include "t/generated-code2/test-full-cxx-output.inc"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
+
 #define TEST_ENUM_SMALL_TYPE_NAME   Foo__TestEnumSmall
 #define TEST_ENUM_SMALL(shortname)   FOO__TEST_ENUM_SMALL__##shortname
 #define TEST_ENUM_TYPE_NAME   Foo__TestEnum


### PR DESCRIPTION
Turn off some compiler diagnostics that clutter the build output and aren't particularly useful.