### PR TITLE
[cmake] Do not manage Protobuf definitions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -66,6 +66,9 @@ pkgconfig_DATA += protobuf-c/libprotobuf-c.pc
 CLEANFILES += protobuf-c/libprotobuf-c.pc
 EXTRA_DIST += protobuf-c/libprotobuf-c.pc.in
 
+cmakedir = $(prefix)/lib/cmake/@PACKAGE@/
+cmake_DATA = protobuf-c/protobuf-c.cmake
+
 #
 # protoc-gen-c
 #

--- a/build-cmake/CMakeLists.txt
+++ b/build-cmake/CMakeLists.txt
@@ -70,7 +70,6 @@ if (MSVC AND NOT BUILD_SHARED_LIBS)
 endif (MSVC AND NOT BUILD_SHARED_LIBS)
 
 FIND_PACKAGE(Protobuf REQUIRED)
-INCLUDE_DIRECTORIES(${PROTOBUF_INCLUDE_DIR})
 
 ENDIF()
 
@@ -83,7 +82,7 @@ if (MSVC AND NOT BUILD_SHARED_LIBS)
 	foreach(flag_var
 		CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
 		CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO
-		CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE 
+		CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
 		CMAKE_C_FLAGS_MINSIZEREL CMAKE_FLAGS_RELWITHDEBINFO)
 	  if(${flag_var} MATCHES "/MD")
 		string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
@@ -96,8 +95,8 @@ SET(CMAKE_CXX_STANDARD 17)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 SET(CMAKE_CXX_EXTENSIONS OFF)
 ADD_CUSTOM_COMMAND(OUTPUT protobuf-c/protobuf-c.pb.cc protobuf-c/protobuf-c.pb.h
-                   COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
-                   ARGS --cpp_out ${CMAKE_CURRENT_BINARY_DIR} -I${PROTOBUF_INCLUDE_DIR} -I${MAIN_DIR} ${MAIN_DIR}/protobuf-c/protobuf-c.proto)
+                   COMMAND ${Protobuf_PROTOC_EXECUTABLE}
+                   ARGS --cpp_out ${CMAKE_CURRENT_BINARY_DIR} -I${Protobuf_INCLUDE_DIR} -I${MAIN_DIR} ${MAIN_DIR}/protobuf-c/protobuf-c.proto)
 FILE(GLOB PROTOC_GEN_C_SRC ${MAIN_DIR}/protoc-c/*.h ${MAIN_DIR}/protoc-c/*.cc )
 ADD_EXECUTABLE(protoc-gen-c ${PROTOC_GEN_C_SRC} protobuf-c/protobuf-c.pb.cc protobuf-c/protobuf-c.pb.h)
 target_include_directories(protoc-gen-c
@@ -109,14 +108,14 @@ target_link_libraries(protoc-gen-c protobuf::libprotoc protobuf::libprotobuf)
 
 IF (MSVC AND BUILD_SHARED_LIBS)
 	TARGET_COMPILE_DEFINITIONS(protoc-gen-c PRIVATE -DPROTOBUF_USE_DLLS)
-	GET_FILENAME_COMPONENT(PROTOBUF_DLL_DIR ${PROTOBUF_PROTOC_EXECUTABLE} DIRECTORY)
+	GET_FILENAME_COMPONENT(PROTOBUF_DLL_DIR ${Protobuf_PROTOC_EXECUTABLE} DIRECTORY)
 	FILE(GLOB PROTOBUF_DLLS ${PROTOBUF_DLL_DIR}/*.dll)
 	FILE(COPY ${PROTOBUF_DLLS} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 ENDIF (MSVC AND BUILD_SHARED_LIBS)
 
 FUNCTION(GENERATE_TEST_SOURCES PROTO_FILE SRC HDR)
 	ADD_CUSTOM_COMMAND(OUTPUT ${SRC} ${HDR}
-                   COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
+                   COMMAND ${Protobuf_PROTOC_EXECUTABLE}
                    ARGS --plugin=$<TARGET_FILE:protoc-gen-c> -I${MAIN_DIR} ${PROTO_FILE} --c_out=${CMAKE_CURRENT_BINARY_DIR}
                    DEPENDS protoc-gen-c)
 ENDFUNCTION()
@@ -132,13 +131,13 @@ TARGET_LINK_LIBRARIES(test-generated-code protobuf-c)
 
 
 ADD_CUSTOM_COMMAND(OUTPUT t/test-full.pb.cc t/test-full.pb.h
-                   COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
+                   COMMAND ${Protobuf_PROTOC_EXECUTABLE}
                    ARGS --cpp_out ${CMAKE_CURRENT_BINARY_DIR} -I${MAIN_DIR} ${TEST_DIR}/test-full.proto)
 
 GENERATE_TEST_SOURCES(${TEST_DIR}/test-full.proto t/test-full.pb-c.c t/test-full.pb-c.h)
 
 ADD_EXECUTABLE(cxx-generate-packed-data ${TEST_DIR}/generated-code2/cxx-generate-packed-data.cc t/test-full.pb.h t/test-full.pb.cc protobuf-c/protobuf-c.pb.cc protobuf-c/protobuf-c.pb.h)
-TARGET_LINK_LIBRARIES(cxx-generate-packed-data ${PROTOBUF_LIBRARY})
+TARGET_LINK_LIBRARIES(cxx-generate-packed-data protobuf::libprotobuf)
 IF (MSVC AND BUILD_SHARED_LIBS)
 	TARGET_COMPILE_DEFINITIONS(cxx-generate-packed-data PRIVATE -DPROTOBUF_USE_DLLS)
 ENDIF (MSVC AND BUILD_SHARED_LIBS)

--- a/build-cmake/CMakeLists.txt
+++ b/build-cmake/CMakeLists.txt
@@ -29,10 +29,6 @@ if (${WORDS_BIGENDIAN})
 	ADD_DEFINITIONS(-DWORDS_BIGENDIAN)
 endif()
 
-IF (MSVC AND BUILD_SHARED_LIBS)
-	ADD_DEFINITIONS(-DPROTOBUF_C_USE_SHARED_LIB)
-ENDIF (MSVC AND BUILD_SHARED_LIBS)
-
 if(MSVC)
   # using Visual Studio C++
   SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4267 /wd4244")
@@ -106,13 +102,6 @@ target_include_directories(protoc-gen-c
 )
 target_link_libraries(protoc-gen-c protobuf::libprotoc protobuf::libprotobuf)
 
-IF (MSVC AND BUILD_SHARED_LIBS)
-	TARGET_COMPILE_DEFINITIONS(protoc-gen-c PRIVATE -DPROTOBUF_USE_DLLS)
-	GET_FILENAME_COMPONENT(PROTOBUF_DLL_DIR ${Protobuf_PROTOC_EXECUTABLE} DIRECTORY)
-	FILE(GLOB PROTOBUF_DLLS ${PROTOBUF_DLL_DIR}/*.dll)
-	FILE(COPY ${PROTOBUF_DLLS} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-ENDIF (MSVC AND BUILD_SHARED_LIBS)
-
 FUNCTION(GENERATE_TEST_SOURCES PROTO_FILE SRC HDR)
 	ADD_CUSTOM_COMMAND(OUTPUT ${SRC} ${HDR}
                    COMMAND ${Protobuf_PROTOC_EXECUTABLE}
@@ -138,9 +127,6 @@ GENERATE_TEST_SOURCES(${TEST_DIR}/test-full.proto t/test-full.pb-c.c t/test-full
 
 ADD_EXECUTABLE(cxx-generate-packed-data ${TEST_DIR}/generated-code2/cxx-generate-packed-data.cc t/test-full.pb.h t/test-full.pb.cc protobuf-c/protobuf-c.pb.cc protobuf-c/protobuf-c.pb.h)
 TARGET_LINK_LIBRARIES(cxx-generate-packed-data protobuf::libprotobuf)
-IF (MSVC AND BUILD_SHARED_LIBS)
-	TARGET_COMPILE_DEFINITIONS(cxx-generate-packed-data PRIVATE -DPROTOBUF_USE_DLLS)
-ENDIF (MSVC AND BUILD_SHARED_LIBS)
 
 FILE(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/t/generated-code2)
 ADD_CUSTOM_COMMAND(OUTPUT t/generated-code2/test-full-cxx-output.inc

--- a/build-cmake/CMakeLists.txt
+++ b/build-cmake/CMakeLists.txt
@@ -195,6 +195,7 @@ install(TARGETS ${PROTOBUF_C_TARGETS}
 
 INSTALL(FILES ${MAIN_DIR}/protobuf-c/protobuf-c.h ${MAIN_DIR}/protobuf-c/protobuf-c.proto DESTINATION include/protobuf-c)
 INSTALL(FILES ${MAIN_DIR}/protobuf-c/protobuf-c.h DESTINATION include)
+INSTALL(FILES ${MAIN_DIR}/protobuf-c/protobuf-c.cmake DESTINATION lib/cmake/protobuf-c)
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/protobuf-c.pdb DESTINATION lib OPTIONAL)
 
 SET(prefix ${CMAKE_INSTALL_PREFIX})

--- a/protobuf-c/protobuf-c.cmake
+++ b/protobuf-c/protobuf-c.cmake
@@ -1,0 +1,72 @@
+find_package(Protobuf REQUIRED)
+find_program(PROTOC_GEN_C protoc-gen-c REQUIRED)
+
+function(protobuf_generate_c SRCS HDRS)
+  cmake_parse_arguments(protobuf_generate_c "" "EXPORT_MACRO;DESCRIPTORS" ""
+      ${ARGN})
+
+  set(_proto_files "${protobuf_generate_c_UNPARSED_ARGUMENTS}")
+  if(NOT _proto_files)
+    message(
+        SEND_ERROR "Error: protobuf_generate_c() called without any proto files")
+    return()
+  endif()
+
+  if(protobuf_generate_c_APPEND_PATH)
+    set(_append_arg APPEND_PATH)
+  endif()
+
+  if(protobuf_generate_c_DESCRIPTORS)
+    set(_descriptors DESCRIPTORS)
+  endif()
+
+  if(DEFINED Protobuf_IMPORT_DIRS)
+    set(_import_arg IMPORT_DIRS ${Protobuf_IMPORT_DIRS})
+  endif()
+
+  set(_outvar)
+  protobuf_generate(
+      ${_append_arg}
+      ${_descriptors}
+      LANGUAGE
+      c
+      PLUGIN
+      ${PROTOC_GEN_C}
+      GENERATE_EXTENSIONS
+      .pb-c.h
+      .pb-c.c
+      EXPORT_MACRO
+      ${protobuf_generate_c_EXPORT_MACRO}
+      OUT_VAR
+      _outvar
+      ${_import_arg}
+      PROTOS
+      ${_proto_files})
+
+  set(${SRCS})
+  set(${HDRS})
+  if(protobuf_generate_c_DESCRIPTORS)
+    set(${protobuf_generate_c_DESCRIPTORS})
+  endif()
+
+  foreach(_file ${_outvar})
+    if(_file MATCHES "c$")
+      list(APPEND ${SRCS} ${_file})
+    elseif(_file MATCHES "desc$")
+      list(APPEND ${protobuf_generate_c_DESCRIPTORS} ${_file})
+    else()
+      list(APPEND ${HDRS} ${_file})
+    endif()
+  endforeach()
+  set(${SRCS}
+      ${${SRCS}}
+      PARENT_SCOPE)
+  set(${HDRS}
+      ${${HDRS}}
+      PARENT_SCOPE)
+  if(protobuf_generate_c_DESCRIPTORS)
+    set(${protobuf_generate_c_DESCRIPTORS}
+        "${${protobuf_generate_c_DESCRIPTORS}}"
+        PARENT_SCOPE)
+  endif()
+endfunction()


### PR DESCRIPTION
This PR is a follow-up to #555 and can be merged there directly or can wait #555 first.

When using official Protobuf targets `protobuf::libprotobuf` and `protobuf::libprotoc`, those definitions that manage shared/stating linkage on Windows should be provided directly by them, so we don't need to manage it directly in Protobuf-C

Source: https://gitlab.kitware.com/cmake/cmake/blob/master/Modules/FindProtobuf.cmake

https://gitlab.kitware.com/cmake/cmake/blob/master/Modules/FindProtobuf.cmake#L660

/cc @gegles