### PR TITLE
SPM support for protobuf-c

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.4
+
+import PackageDescription
+
+let package = Package(
+    name: "protobuf-c",
+    products: [
+        .library(name: "protobuf-c", targets: ["protobuf-c"]),
+    ],
+    targets: [
+        .target(
+            name: "protobuf-c",
+            path: "./protobuf-c",
+            sources: [
+                "protobuf-c.c"
+            ]
+        )
+    ]
+)

--- a/protobuf-c/include/protobuf-c/protobuf-c.h
+++ b/protobuf-c/include/protobuf-c/protobuf-c.h
@@ -1,0 +1,1 @@
+../../protobuf-c.h


### PR DESCRIPTION
This pull request introduces support for Swift Package Manager (SPM) within the protobuf-c project. Due to the specific requirements of SPM regarding project structure, I've created a symlink `include/protobuf-c` to comply with these demands.

Unfortunately, at this time, I was unable to create an executable target for `proto-c`, as it relies on Google's dependencies that currently lack SPM support.