### PR TITLE
MSVC workflow to generate binaries

### DIFF
--- a/.github/workflows/msvc_bin.yml
+++ b/.github/workflows/msvc_bin.yml
@@ -8,7 +8,7 @@ on:
                 default: 'https://github.com/protocolbuffers/protobuf.git'
                 type: string
             protobuf_branch:
-                description: 'branch associated with the protobuf repo'
+                description: 'branch/tag/commit associated with the protobuf repo'
                 default: 'main'
                 type: string
             protobuf-c_repo:
@@ -16,11 +16,11 @@ on:
                 default: 'https://github.com/protobuf-c/protobuf-c.git'
                 type: string
             protobuf-c_branch:
-                description: 'branch associated with the protobuf-c repo'
+                description: 'branch/tag/commit associated with the protobuf-c repo'
                 default: 'next'
                 type: string
             abseil_branch:
-                description: 'branch associated with the abseil-cpp repo'
+                description: 'branch/tag/commit associated with the abseil-cpp repo'
                 default: 'master'
                 type: string
 
@@ -39,8 +39,9 @@ jobs:
         steps:
             - name: Set up an independent abseil repo
               run: |
-                   git clone --depth=1 --branch ${{ inputs.abseil_branch }} https://github.com/abseil/abseil-cpp.git
+                   git clone https://github.com/abseil/abseil-cpp.git
                    cd abseil-cpp
+                   git checkout ${{ inputs.abseil_branch }}
                    $runtime = 'MultiThreaded$<$<CONFIG:Debug>:Debug>'
                    if ('${{ matrix.shared_libs }}' -eq 'ON')
                    { $runtime += 'DLL' }
@@ -54,7 +55,7 @@ jobs:
             - name: Set up the utf8 compression algorithm
               if: ${{ matrix.shared_libs == 'OFF' }}
               run: |
-                   git clone --depth=1 https://github.com/protocolbuffers/utf8_range.git
+                   git clone https://github.com/protocolbuffers/utf8_range.git
                    cd utf8_range
                    cmake -DCMAKE_CXX_STANDARD=17 -Dutf8_range_ENABLE_TESTS=OFF `
                          -DBUILD_SHARED_LIBS=OFF `
@@ -68,8 +69,9 @@ jobs:
 
             - name: Set up protobuf repo
               run: |
-                   git clone --depth=1 --branch ${{ inputs.protobuf_branch }} --recurse-submodules ${{ inputs.protobuf_repo }}
+                   git clone --recurse-submodules ${{ inputs.protobuf_repo }}
                    cd protobuf
+                   git checkout ${{ inputs.protobuf_branch }} 
                    cmake -DCMAKE_CXX_STANDARD=17 `
                          -DBUILD_SHARED_LIBS=${{ matrix.shared_libs }} `
                          -Dprotobuf_BUILD_TESTS=OFF `
@@ -84,8 +86,9 @@ jobs:
             - name: Set up protobuf-c repo
               id: build
               run: |
-                   git clone --depth=1 --branch ${{ inputs.protobuf-c_branch }} --recurse-submodules ${{ inputs.protobuf-c_repo }}
+                   git clone --recurse-submodules ${{ inputs.protobuf-c_repo }}
                    cd protobuf-c
+                   git checkout ${{ inputs.protobuf-c_branch }}
                    cmake -DCMAKE_CXX_STANDARD=17 `
                          -DProtobuf_ROOT="$Env:TMP/install/protobuf" `
                          -DBUILD_SHARED_LIBS=${{ matrix.shared_libs }} `
@@ -119,8 +122,9 @@ jobs:
 
             - name: Set up an independent abseil repo
               run: |
-                   git clone --depth=1 --branch ${{ inputs.abseil_branch }} https://github.com/abseil/abseil-cpp.git
+                   git clone https://github.com/abseil/abseil-cpp.git
                    cd abseil-cpp
+                   git checkout ${{ inputs.abseil_branch }}
                    $runtime = 'MultiThreaded$<$<CONFIG:Debug>:Debug>'
                    if ('${{ matrix.shared_libs }}' -eq 'ON')
                    { $runtime += 'DLL' }
@@ -134,7 +138,7 @@ jobs:
             - name: Set up the utf8 compression algorithm
               if: ${{ matrix.shared_libs == 'OFF' }}
               run: |
-                   git clone --depth=1 https://github.com/protocolbuffers/utf8_range.git
+                   git clone https://github.com/protocolbuffers/utf8_range.git
                    cd utf8_range
                    cmake -DCMAKE_CXX_STANDARD=17 -Dutf8_range_ENABLE_TESTS=OFF `
                          -DBUILD_SHARED_LIBS=OFF `
@@ -148,8 +152,9 @@ jobs:
 
             - name: Set up protobuf repo
               run: |
-                   git clone --depth=1 --branch ${{ inputs.protobuf_branch }} --recurse-submodules ${{ inputs.protobuf_repo }}
+                   git clone --recurse-submodules ${{ inputs.protobuf_repo }}
                    cd protobuf
+                   git checkout ${{ inputs.protobuf_branch }} 
                    cmake -DCMAKE_CXX_STANDARD=17 `
                          -DBUILD_SHARED_LIBS=${{ matrix.shared_libs }} `
                          -Dprotobuf_BUILD_TESTS=OFF `
@@ -164,8 +169,9 @@ jobs:
             - name: Set up protobuf-c repo
               id: build
               run: |
-                   git clone --depth=1 --branch ${{ inputs.protobuf-c_branch }} --recurse-submodules ${{ inputs.protobuf-c_repo }}
+                   git clone --recurse-submodules ${{ inputs.protobuf-c_repo }}
                    cd protobuf-c
+                   git checkout ${{ inputs.protobuf-c_branch }} 
                    cmake -DCMAKE_CXX_STANDARD=17 `
                          -DProtobuf_ROOT="$Env:TMP/install/protobuf" `
                          -DBUILD_SHARED_LIBS=${{ matrix.shared_libs }} `

--- a/.github/workflows/msvc_bin.yml
+++ b/.github/workflows/msvc_bin.yml
@@ -1,0 +1,184 @@
+name: Windows/MSVC binary generation
+
+on:
+    workflow_dispatch:
+        inputs:
+            protobuf_repo:
+                description: 'repo associated to the protobuf repo'
+                default: 'https://github.com/MiguelBarro/protobuf.git'
+                type: string
+            protobuf_branch:
+                description: 'branch associated with the protobuf repo'
+                default: 'main'
+                type: string
+            protobuf-c_repo:
+                description: 'repo associated to the protobuf-c repo'
+                default: 'https://github.com/MiguelBarro/protobuf-c.git'
+                type: string
+            protobuf-c_branch:
+                description: 'branch associated with the protobuf-c repo'
+                default: 'master'
+                type: string
+            abseil_branch:
+                description: 'branch associated with the abseil-cpp repo'
+                default: 'master'
+                type: string
+
+defaults:
+    run:
+        shell: pwsh
+
+jobs:
+    build-binaries:
+        strategy:
+            matrix:
+                config: [Debug, Release]
+                shared_libs: [ON, OFF]
+            fail-fast: false
+        runs-on: windows-latest
+        steps:
+            - name: Set up an independent abseil repo
+              run: |
+                   git clone --depth=1 --branch ${{ inputs.abseil_branch }} https://github.com/abseil/abseil-cpp.git
+                   cd abseil-cpp
+                   $runtime = 'MultiThreaded$<$<CONFIG:Debug>:Debug>'
+                   if ('${{ matrix.shared_libs }}' -eq 'ON')
+                   { $runtime += 'DLL' }
+                   cmake -DABSL_USE_EXTERNAL_GOOGLETEST=ON -DABSL_FIND_GOOGLETEST=ON `
+                         -DBUILD_SHARED_LIBS=${{ matrix.shared_libs }} -DABSL_PROPAGATE_CXX_STD=ON `
+                         -DCMAKE_MSVC_RUNTIME_LIBRARY="$runtime" `
+                         -DCMAKE_CXX_STANDARD=17 -B build -A x64 -T host=x64 .
+                   cmake --build build --config ${{ matrix.config }}
+                   cmake --install build --config ${{ matrix.config }} --prefix "$Env:TMP/install/absl"
+
+            - name: Set up the utf8 compression algorithm
+              if: ${{ matrix.shared_libs == 'OFF' }}
+              run: |
+                   git clone --depth=1 https://github.com/protocolbuffers/utf8_range.git
+                   cd utf8_range
+                   cmake -DCMAKE_CXX_STANDARD=17 -Dutf8_range_ENABLE_TESTS=OFF `
+                         -DBUILD_SHARED_LIBS=OFF `
+                         -Dabsl_ROOT="$Env:TMP/install/absl" `
+                         -DCMAKE_POLICY_DEFAULT_CMP0074=NEW `
+                         -DCMAKE_POLICY_DEFAULT_CMP0091=NEW `
+                         -DCMAKE_MSVC_RUNTIME_LIBRARY='MultiThreaded$<$<CONFIG:Debug>:Debug>' `
+                         -B build -A x64 -T host=x64 .
+                   cmake --build build --config ${{ matrix.config }}
+                   cmake --install build --config ${{ matrix.config }} --prefix "$Env:TMP/install/utf8_range"
+
+            - name: Set up protobuf repo
+              run: |
+                   git clone --depth=1 --branch ${{ inputs.protobuf_branch }} --recurse-submodules ${{ inputs.protobuf_repo }}
+                   cd protobuf
+                   cmake -DCMAKE_CXX_STANDARD=17 `
+                         -DBUILD_SHARED_LIBS=${{ matrix.shared_libs }} `
+                         -Dprotobuf_BUILD_TESTS=OFF `
+                         -Dprotobuf_BUILD_EXAMPLES=OFF `
+                         -Dprotobuf_ABSL_PROVIDER=package `
+                         -Dabsl_ROOT="$Env:TMP/install/absl" `
+                         -DABSL_PROPAGATE_CXX_STD=ON `
+                         -B build -A x64 -T host=x64 .
+                   cmake --build build --config ${{ matrix.config }}
+                   cmake --install build --config ${{ matrix.config }} --prefix "$Env:TMP/install/protobuf"
+
+            - name: Set up protobuf-c repo
+              id: build
+              run: |
+                   git clone --depth=1 --branch ${{ inputs.protobuf-c_branch }} --recurse-submodules ${{ inputs.protobuf-c_repo }}
+                   cd protobuf-c
+                   cmake -DCMAKE_CXX_STANDARD=17 `
+                         -DProtobuf_ROOT="$Env:TMP/install/protobuf" `
+                         -DBUILD_SHARED_LIBS=${{ matrix.shared_libs }} `
+                         -DBUILD_TESTS=OFF `
+                         -Dabsl_ROOT="$Env:TMP/install/absl" `
+                         -Dutf8_range_ROOT="$Env:TMP/install/utf8_range" `
+                         -B build-cmake/build -A x64 -T host=x64 build-cmake
+                   cmake --build build-cmake/build --config ${{ matrix.config }}
+                   cmake --install build-cmake/build --config ${{ matrix.config }} --prefix "$Env:TMP/install/protobuf-c"
+                   "BINARYDIR=$Env:TMP/install" | Out-File $Env:GITHUB_OUTPUT
+
+            - name: Upload artifacts
+              uses: actions/upload-artifact@v3
+              with:
+                name: protobuf-c-binaries-${{ matrix.config }}-${{ matrix.shared_libs == 'ON' && 'dll' || 'lib'}}
+                path: ${{ steps.build.outputs.BINARYDIR }}
+
+    build-binaries-nmake:
+        strategy:
+            matrix:
+                config: [Debug, Release]
+                shared_libs: [ON, OFF]
+            fail-fast: false
+        runs-on: windows-latest
+        steps:
+
+            - name: Enforce a developer console
+              uses: ilammy/msvc-dev-cmd@v1
+              with:
+                  arch: amd64
+
+            - name: Set up an independent abseil repo
+              run: |
+                   git clone --depth=1 --branch ${{ inputs.abseil_branch }} https://github.com/abseil/abseil-cpp.git
+                   cd abseil-cpp
+                   $runtime = 'MultiThreaded$<$<CONFIG:Debug>:Debug>'
+                   if ('${{ matrix.shared_libs }}' -eq 'ON')
+                   { $runtime += 'DLL' }
+                   cmake -DABSL_USE_EXTERNAL_GOOGLETEST=ON -DABSL_FIND_GOOGLETEST=ON `
+                         -DBUILD_SHARED_LIBS=${{ matrix.shared_libs }} -DABSL_PROPAGATE_CXX_STD=ON `
+                         -DCMAKE_MSVC_RUNTIME_LIBRARY="$runtime" `
+                         -B build -DCMAKE_CXX_STANDARD=17 -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=${{ matrix.config }} .
+                   cmake --build build
+                   cmake --install build --prefix "$Env:TMP/install/absl"
+
+            - name: Set up the utf8 compression algorithm
+              if: ${{ matrix.shared_libs == 'OFF' }}
+              run: |
+                   git clone --depth=1 https://github.com/protocolbuffers/utf8_range.git
+                   cd utf8_range
+                   cmake -DCMAKE_CXX_STANDARD=17 -Dutf8_range_ENABLE_TESTS=OFF `
+                         -DBUILD_SHARED_LIBS=OFF `
+                         -Dabsl_ROOT="$Env:TMP/install/absl" `
+                         -DCMAKE_POLICY_DEFAULT_CMP0074=NEW `
+                         -DCMAKE_POLICY_DEFAULT_CMP0091=NEW `
+                         -DCMAKE_MSVC_RUNTIME_LIBRARY='MultiThreaded$<$<CONFIG:Debug>:Debug>' `
+                         -B build -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=${{ matrix.config }} .
+                   cmake --build build
+                   cmake --install build --prefix "$Env:TMP/install/utf8_range"
+
+            - name: Set up protobuf repo
+              run: |
+                   git clone --depth=1 --branch ${{ inputs.protobuf_branch }} --recurse-submodules ${{ inputs.protobuf_repo }}
+                   cd protobuf
+                   cmake -DCMAKE_CXX_STANDARD=17 `
+                         -DBUILD_SHARED_LIBS=${{ matrix.shared_libs }} `
+                         -Dprotobuf_BUILD_TESTS=OFF `
+                         -Dprotobuf_BUILD_EXAMPLES=OFF `
+                         -Dprotobuf_ABSL_PROVIDER=package `
+                         -Dabsl_ROOT="$Env:TMP/install/absl" `
+                         -DABSL_PROPAGATE_CXX_STD=ON `
+                         -B build -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=${{ matrix.config }} .
+                   cmake --build build
+                   cmake --install build --prefix "$Env:TMP/install/protobuf"
+
+            - name: Set up protobuf-c repo
+              id: build
+              run: |
+                   git clone --depth=1 --branch ${{ inputs.protobuf-c_branch }} --recurse-submodules ${{ inputs.protobuf-c_repo }}
+                   cd protobuf-c
+                   cmake -DCMAKE_CXX_STANDARD=17 `
+                         -DProtobuf_ROOT="$Env:TMP/install/protobuf" `
+                         -DBUILD_SHARED_LIBS=${{ matrix.shared_libs }} `
+                         -DBUILD_TESTS=OFF `
+                         -Dabsl_ROOT="$Env:TMP/install/absl" `
+                         -Dutf8_range_ROOT="$Env:TMP/install/utf8_range" `
+                         -B build-cmake/build -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=${{ matrix.config }} build-cmake
+                   cmake --build build-cmake/build
+                   cmake --install build-cmake/build --prefix "$Env:TMP/install/protobuf-c"
+                   "BINARYDIR=$Env:TMP/install" | Out-File $Env:GITHUB_OUTPUT
+
+            - name: Upload artifacts
+              uses: actions/upload-artifact@v3
+              with:
+                name: nmake-protobuf-c-binaries-${{ matrix.config }}-${{ matrix.shared_libs == 'ON' && 'dll' || 'lib'}}
+                path: ${{ steps.build.outputs.BINARYDIR }}

--- a/.github/workflows/msvc_bin.yml
+++ b/.github/workflows/msvc_bin.yml
@@ -5,7 +5,7 @@ on:
         inputs:
             protobuf_repo:
                 description: 'repo associated to the protobuf repo'
-                default: 'https://github.com/MiguelBarro/protobuf.git'
+                default: 'https://github.com/protocolbuffers/protobuf.git'
                 type: string
             protobuf_branch:
                 description: 'branch associated with the protobuf repo'
@@ -13,7 +13,7 @@ on:
                 type: string
             protobuf-c_repo:
                 description: 'repo associated to the protobuf-c repo'
-                default: 'https://github.com/MiguelBarro/protobuf-c.git'
+                default: 'https://github.com/protobuf-c/protobuf-c.git'
                 type: string
             protobuf-c_branch:
                 description: 'branch associated with the protobuf-c repo'

--- a/.github/workflows/msvc_bin.yml
+++ b/.github/workflows/msvc_bin.yml
@@ -17,7 +17,7 @@ on:
                 type: string
             protobuf-c_branch:
                 description: 'branch associated with the protobuf-c repo'
-                default: 'master'
+                default: 'next'
                 type: string
             abseil_branch:
                 description: 'branch associated with the abseil-cpp repo'


### PR DESCRIPTION
Introduced a convenient github workflow to generate MSVC binaries for different protobuf/protobuf-c branches.
The idea is to allow users to generate Windows binaries, especially static-linked ones. They are not available via Releases or package managers (neither winget nor choco), unlike linux distros.
This pull request must be merged after https://github.com/protobuf-c/protobuf-c/pull/685.