### PR TITLE
Fix memory corruption by initlizalizing pointer

### DIFF
--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -3278,6 +3278,8 @@ protobuf_c_message_unpack(const ProtobufCMessageDescriptor *desc,
 					      n_unknown * sizeof(ProtobufCMessageUnknownField));
 		if (rv->unknown_fields == NULL)
 			goto error_cleanup;
+	} else {
+		rv->unknown_fields = NULL;
 	}
 
 	/* do real parsing */


### PR DESCRIPTION
A memory corruption in protobuf_c_message_free_unpacked happens at the following line:

        if (message->unknown_fields != NULL)
                do_free(allocator, message->unknown_fields);

The do_free will free ->unknown_fields. This is may be wrong, because protobuf_c_message_unpack uses malloc as the default allocator, allocates rv with malloc. At the end, however, ->unknown_fields is only initialized if there are some. That means if there are no such fields ->unknown_fields is an uninitialized pointer.

The patch initializes the pointer to NULL to ensure the check before free is performed on initialized memory in case there is no unknown_field.

This fixes https://github.com/protobuf-c/protobuf-c/issues/690