### PR TITLE
supports proto3 optional fields.

### DIFF
--- a/protoc-c/c_generator.h
+++ b/protoc-c/c_generator.h
@@ -93,6 +93,11 @@ class PROTOC_C_EXPORT CGenerator : public CodeGenerator {
                 const std::string& parameter,
                 OutputDirectory* output_directory,
                 std::string* error) const;
+
+  uint64_t GetSupportedFeatures() const override {
+    // Indicate that this code generator supports proto3 optional fields.
+    return FEATURE_PROTO3_OPTIONAL;
+  }
 };
 
 }  // namespace c


### PR DESCRIPTION
Fixed proto3 not supporting optional fields.

An example is as follows:

syntax = "proto3";

message Example {
  string name = 1;
  optional int32 age = 2; // optional field is used here
}