### PR TITLE
Chase compatibility issues with Google protobuf >= 26.0

### DIFF
--- a/protoc-c/c_file.cc
+++ b/protoc-c/c_file.cc
@@ -117,14 +117,7 @@ FileGenerator::~FileGenerator() {}
 void FileGenerator::GenerateHeader(io::Printer* printer) {
   std::string filename_identifier = FilenameIdentifier(file_->name());
 
-  int min_header_version = 1000000;
-#if GOOGLE_PROTOBUF_VERSION >= 4023000
-  if (FileDescriptorLegacy(file_).syntax() == FileDescriptorLegacy::SYNTAX_PROTO3) {
-#else
-  if (file_->syntax() == FileDescriptor::SYNTAX_PROTO3) {
-#endif
-    min_header_version = 1003000;
-  }
+  const int min_header_version = 1003000;
 
   // Generate top of header.
   printer->Print(

--- a/protoc-c/c_generator.h
+++ b/protoc-c/c_generator.h
@@ -93,6 +93,12 @@ class PROTOC_C_EXPORT CGenerator : public CodeGenerator {
                 const std::string& parameter,
                 OutputDirectory* output_directory,
                 std::string* error) const;
+
+#if GOOGLE_PROTOBUF_VERSION >= 5026000
+  uint64_t GetSupportedFeatures() const { return CodeGenerator::FEATURE_SUPPORTS_EDITIONS; }
+  Edition GetMinimumEdition() const { return Edition::EDITION_PROTO2; }
+  Edition GetMaximumEdition() const { return Edition::EDITION_PROTO3; }
+#endif
 };
 
 }  // namespace c

--- a/protoc-c/c_generator.h
+++ b/protoc-c/c_generator.h
@@ -95,7 +95,7 @@ class PROTOC_C_EXPORT CGenerator : public CodeGenerator {
                 std::string* error) const;
 
 #if GOOGLE_PROTOBUF_VERSION >= 5026000
-  uint64_t GetSupportedFeatures() const { return CodeGenerator::FEATURE_SUPPORTS_EDITIONS; }
+  uint64_t GetSupportedFeatures() const { return 0; }
   Edition GetMinimumEdition() const { return Edition::EDITION_PROTO2; }
   Edition GetMaximumEdition() const { return Edition::EDITION_PROTO3; }
 #endif

--- a/protoc-c/c_helpers.h
+++ b/protoc-c/c_helpers.h
@@ -70,10 +70,6 @@
 #include <protobuf-c/protobuf-c.pb.h>
 #include <google/protobuf/io/printer.h>
 
-#if GOOGLE_PROTOBUF_VERSION >= 4023000
-# include <google/protobuf/descriptor_legacy.h>
-#endif
-
 namespace google {
 namespace protobuf {
 namespace compiler {
@@ -173,13 +169,21 @@ struct NameIndex
 int compare_name_indices_by_name(const void*, const void*);
 
 // Return the syntax version of the file containing the field.
-// This wrapper is needed to be able to compile against protobuf2.
 inline int FieldSyntax(const FieldDescriptor* field) {
-#if GOOGLE_PROTOBUF_VERSION >= 4023000
-  return FileDescriptorLegacy(field->file()).syntax() == FileDescriptorLegacy::SYNTAX_PROTO3 ? 3 : 2;
-#else
-  return field->file()->syntax() == FileDescriptor::SYNTAX_PROTO3 ? 3 : 2;
-#endif
+  auto proto = FileDescriptorProto();
+  field->file()->CopyTo(&proto);
+
+  if (proto.has_syntax()) {
+    auto syntax = proto.syntax();
+    assert(syntax == "proto2" || syntax == "proto3");
+    if (syntax == "proto2") {
+      return 2;
+    } else if (syntax == "proto3") {
+      return 3;
+    }
+  }
+
+  return 2;
 }
 
 // Work around changes in protobuf >= 22.x without breaking compilation against


### PR DESCRIPTION
This branch should fix several compatibility issues with the most recent Google protobuf release (26.0).

The Google protobuf `FileDescriptorLegacy::syntax()` method no longer exists in protobuf 26.0, and the `FileDescriptorLegacy` class itself is apparently deprecated and will be removed, so the `FieldSyntax()` helper in protobuf-c has been reimplemented by querying the `FileDescriptorProto` object directly. This appears to work on a wide range of Google protobuf versions at least as far back as the one shipped in Ubuntu 20.04 without any version-specific workarounds. Hopefully it continues to work.

`FileGenerator::GenerateHeader()` was also relying on `FileDescriptorLegacy::syntax()`, but we don't really need to cater to versions of protobuf-c that are now 7-10 years old, so this method has been simplified to just unconditionally set a minimum header version of 1.3.0.

Finally, the Google protobuf project is experimenting with new "editions" (https://protobuf.dev/editions/overview/) of the .proto file format. It looks like the goal is to introduce a bunch of new .proto file syntax for enabling compiler features on a per-field basis. Since this is experimental and protobuf-c doesn't support any of it, if compiled with Google protobuf 26.0 or later the protobuf-c `CodeGenerator` class will declare that that it supports "editions" but restrict the supported editions to proto2 and proto3.