### PR TITLE
Fix CI issues with CMake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Linux dependencies
         if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt-get install -y protobuf-compiler libprotobuf-dev libprotoc-dev
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y protobuf-compiler libprotobuf-dev libprotoc-dev
       - name: Install Mac dependencies
         if: startsWith(matrix.os, 'macos')
         run: brew install protobuf automake
@@ -60,7 +62,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt-get install -y protobuf-compiler libprotobuf-dev libprotoc-dev valgrind
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y protobuf-compiler libprotobuf-dev libprotoc-dev valgrind
       - name: Run distcheck with valgrind
         run: |
           ./autogen.sh
@@ -72,7 +76,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt-get install -y protobuf-compiler libprotobuf-dev libprotoc-dev lcov
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y protobuf-compiler libprotobuf-dev libprotoc-dev lcov
       - name: Run coverage build
         run: |
           ./autogen.sh
@@ -96,7 +102,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Linux dependencies
         if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt-get install -y protobuf-compiler libprotobuf-dev libprotoc-dev
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y protobuf-compiler libprotobuf-dev libprotoc-dev
       - name: Install Mac dependencies
         if: startsWith(matrix.os, 'macos')
         run: brew install protobuf abseil

--- a/build-cmake/CMakeLists.txt
+++ b/build-cmake/CMakeLists.txt
@@ -20,7 +20,10 @@ if (MSVC AND NOT BUILD_SHARED_LIBS)
 endif (MSVC AND NOT BUILD_SHARED_LIBS)
 
 FIND_PACKAGE(Protobuf CONFIG)
-if(NOT Protobuf_FOUND)
+if(Protobuf_FOUND)
+  # Keep compatibility with FindProtobuf CMake module
+  set(PROTOBUF_PROTOC_EXECUTABLE $<TARGET_FILE:protobuf::protoc>)
+else()
   MESSAGE(STATUS "Protobuf CMake config not found fallback to Cmake Module")
   FIND_PACKAGE(Protobuf REQUIRED)
 endif()

--- a/build-cmake/CMakeLists.txt
+++ b/build-cmake/CMakeLists.txt
@@ -15,7 +15,11 @@ if (MSVC AND NOT BUILD_SHARED_LIBS)
 	SET(Protobuf_USE_STATIC_LIBS ON)
 endif (MSVC AND NOT BUILD_SHARED_LIBS)
 
-FIND_PACKAGE(Protobuf REQUIRED)
+FIND_PACKAGE(Protobuf CONFIG)
+if(NOT Protobuf_FOUND)
+  MESSAGE(STATUS "Protobuf CMake config not found fallback to Cmake Module")
+  FIND_PACKAGE(Protobuf REQUIRED)
+endif()
 file(REAL_PATH "${PROTOBUF_INCLUDE_DIR}" PROTOBUF_INCLUDE_DIR)
 INCLUDE_DIRECTORIES(${PROTOBUF_INCLUDE_DIR})
 
@@ -112,7 +116,7 @@ if (MSVC AND NOT BUILD_SHARED_LIBS)
 	foreach(flag_var
 		CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
 		CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO
-		CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE 
+		CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
 		CMAKE_C_FLAGS_MINSIZEREL CMAKE_FLAGS_RELWITHDEBINFO)
 	  if(${flag_var} MATCHES "/MD")
 		string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
@@ -316,12 +320,12 @@ ADD_TEST(test-version test-version)
 
 if(WIN32)
     set_tests_properties(
-        test-generated-code 
-        test-generated-code2 
-        test-generated-code3 
-        test-issue220 
-        test-issue251 
-        test-version 
+        test-generated-code
+        test-generated-code2
+        test-generated-code3
+        test-issue220
+        test-issue251
+        test-version
         PROPERTIES ENVIRONMENT "PATH=${WINDOWS_PATH_VARIABLE}\\;$<TARGET_FILE_DIR:protoc-gen-c>" )
 endif(WIN32)
 

--- a/build-cmake/CMakeLists.txt
+++ b/build-cmake/CMakeLists.txt
@@ -8,6 +8,10 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.10 FATAL_ERROR)
 cmake_policy(SET CMP0074 NEW)
 cmake_policy(SET CMP0091 NEW)
 cmake_policy(SET CMP0112 NEW)
+# TODO: Convert DART to CTEST
+if(POLICY CMP0145)
+  cmake_policy(SET CMP0145 OLD)
+endif()
 
 PROJECT(protobuf-c C CXX)
 

--- a/build-cmake/CMakeLists.txt
+++ b/build-cmake/CMakeLists.txt
@@ -220,7 +220,7 @@ GENERATE_TEST_SOURCES(${TEST_DIR}/test-full.proto t/test-full.pb-c.c t/test-full
 
 ADD_EXECUTABLE(cxx-generate-packed-data ${TEST_DIR}/generated-code2/cxx-generate-packed-data.cc t/test-full.pb.h t/test-full.pb.cc protobuf-c/protobuf-c.pb.cc protobuf-c/protobuf-c.pb.h)
 TARGET_LINK_LIBRARIES(cxx-generate-packed-data
-    ${PROTOBUF_LIBRARY}
+    protobuf::libprotobuf
     ${protobuf_ABSL_USED_TARGETS}
     ${protobuf_UTF8_USED_TARGETS}
 )


### PR DESCRIPTION
The CMake module is used by default but isn't compatible with recent protobuf version.

Try to first look for a protobuf config then fallback to legacy cmake module.