### PR TITLE
build.yml: Install libtool on OS X

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           sudo apt-get install -y protobuf-compiler libprotobuf-dev libprotoc-dev
       - name: Install Mac dependencies
         if: startsWith(matrix.os, 'macos')
-        run: brew install protobuf automake
+        run: brew install protobuf automake libtool
       - name: Run distcheck
         run: |
           ./autogen.sh


### PR DESCRIPTION
This might fix the new CI build failure:

    → Run ./autogen.sh
    autoreconf: export WARNINGS=
    autoreconf: Entering directory '.'
    autoreconf: configure.ac: not using Gettext
    autoreconf: running: aclocal --force -I m4 ${ACLOCAL_FLAGS}
    autoreconf: configure.ac: tracing
    autoreconf: configure.ac: creating directory build-aux
    autoreconf: configure.ac: not using Libtool
    autoreconf: configure.ac: not using Intltool
    autoreconf: configure.ac: not using Gtkdoc
    autoreconf: running: /opt/homebrew/Cellar/autoconf/2.72/bin/autoconf --force
    autoreconf: running: /opt/homebrew/Cellar/autoconf/2.72/bin/autoheader --force
    autoreconf: running: automake --add-missing --copy --force-missing
    configure.ac:14: installing 'build-aux/compile'
    configure.ac:13: installing 'build-aux/install-sh'
    configure.ac:13: installing 'build-aux/missing'
    Makefile.am:4: error: Libtool library used but 'LIBTOOL' is undefined
    Makefile.am:4:   The usual way to define 'LIBTOOL' is to add 'LT_INIT'
    Makefile.am:4:   to 'configure.ac' and run 'aclocal' and 'autoconf' again.
    Makefile.am:4:   If 'LT_INIT' is in 'configure.ac', make sure
    Makefile.am:4:   its definition is in aclocal's search path.
    Makefile.am: installing 'build-aux/depcomp'
    parallel-tests: installing 'build-aux/test-driver'
    autoreconf: error: automake failed with exit status: 1