### PR TITLE
Introduce __INIT_EX, the recursive initializer macro

### DIFF
--- a/protoc-c/c_file.cc
+++ b/protoc-c/c_file.cc
@@ -227,6 +227,12 @@ void FileGenerator::GenerateHeader(io::Printer* printer) {
     service_generators_[i]->GenerateDescriptorDeclarations(printer);
   }
 
+  printer->Print("\n/* --- static initializers --- */\n\n");
+
+  for (int i = 0; i < file_->message_type_count(); i++) {
+    message_generators_[i]->GenerateStaticInitializerDeclarations(printer);
+  }
+
   printer->Print(
     "\n"
     "PROTOBUF_C__END_DECLS\n"
@@ -260,6 +266,7 @@ void FileGenerator::GenerateSource(io::Printer* printer) {
   for (int i = 0; i < file_->message_type_count(); i++) {
     message_generators_[i]->GenerateMessageDescriptor(printer,
 						      opt.gen_init_helpers());
+    message_generators_[i]->GenerateStaticInitializerDefinitions(printer);
   }
   for (int i = 0; i < file_->enum_type_count(); i++) {
     enum_generators_[i]->GenerateEnumDescriptor(printer);

--- a/protoc-c/c_helpers.h
+++ b/protoc-c/c_helpers.h
@@ -86,6 +86,9 @@ template <typename T> std::string SimpleItoa(T n) {
   return stream.str();
 }
 
+std::string OverrideFullName(const std::string &full_name,
+			    const FileDescriptor *file);
+
 std::string SimpleFtoa(float f);
 std::string SimpleDtoa(double f);
 void SplitStringUsing(const std::string &str, const char *delim, std::vector<std::string> *out);

--- a/protoc-c/c_message.h
+++ b/protoc-c/c_message.h
@@ -97,6 +97,12 @@ class MessageGenerator {
   // Generate descriptor prototype
   void GenerateDescriptorDeclarations(io::Printer* printer);
 
+  // Generate static initializer prototypes
+  void GenerateStaticInitializerDeclarations(io::Printer* printer);
+
+  // Generate static initializers
+  void GenerateStaticInitializerDefinitions(io::Printer* printer);
+
   // Generate descriptor prototype
   void GenerateClosureTypedef(io::Printer* printer);
 


### PR DESCRIPTION
Here we introduce a new set of macros ending in __INIT_EX. These macros take one parameter, msg, which should be the address-of a stack allocated outer message. The __INIT macros are now just global allocations and are no longer macros. This also eliminates storing redundant copies of the initial struct values in every function that needs them. Instead, we just copy them from the global allocation.

Example:

```
MyMessage msg1, msg2 = MY_MESSAGE__INIT;

MY_MESSAGE__INIT_EX(&msg1);

msg1.inner->value = 42;

msg2.inner->value = 69; // seg-fault because __INIT is not recursive

```