### PR TITLE
Miscellaneous CI updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: uraimo/run-on-arch-action@v2.7.2
+      - uses: uraimo/run-on-arch-action@v2
         name: Install dependencies and run distcheck
         id: runcmd
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - next
   pull_request:
   schedule:
-    - cron: '0 0 * * 0' # Every Sunday at 00:00
+    - cron: '0 0 * * 5' # Every Friday at 00:00
 jobs:
   distcheck:
     strategy:


### PR DESCRIPTION
It doesn't seem that the `next` branch is getting regularly built (https://github.com/protobuf-c/protobuf-c/actions?query=branch%3Anext shows the last build was 9 months ago) so let's push some miscellaneous CI updates.