### PR TITLE
build.yml: Build on more pull request activity types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
       - master
       - next
   pull_request:
+    types: [ opened, reopened, synchronize, edited, ready_for_review, review_requested ]
   schedule:
     - cron: '0 0 * * 5' # Every Friday at 00:00
 jobs:


### PR DESCRIPTION
The default is to build on pull request activity types opened, reopened, and synchronize. Also build on activity types edited, ready_for_review, and review_requested.