### PR TITLE
protobuf-c: Zero memory returned by do_alloc()

### DIFF
--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2023, Dave Benson and the protobuf-c authors.
+ * Copyright (c) 2008-2025, Dave Benson and the protobuf-c authors.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -164,7 +164,11 @@ system_free(void *allocator_data, void *data)
 static inline void *
 do_alloc(ProtobufCAllocator *allocator, size_t size)
 {
-	return allocator->alloc(allocator->allocator_data, size);
+	void *data = allocator->alloc(allocator->allocator_data, size);
+	if (data != NULL) {
+		memset(data, 0, size);
+	}
+	return data;
 }
 
 static inline void


### PR DESCRIPTION
There have been reports of memory corruption, for instance the GitHub issues #690 and #745, that are likely due to failure to fully initialize allocated memory along a particular code path.

I have not been able to track down the immediate cause of #745 which is invoked by new optimizations in gcc 15 that are enabled by `-fzero-init-padding-bits=standard`.

Clearing all allocated memory should be safe and any slight performance hit is certainly worth it. It does appear to prevent the crash in #745.