### PR TITLE
build.yml: Update Windows dependencies (abseil, protobuf)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,7 +151,14 @@ jobs:
           cd ~
           git clone --depth=1 https://github.com/abseil/abseil-cpp.git -b ${{ env.ABSEIL_VERSION }} abseil
           cd ~/abseil
-          cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_INSTALL_PREFIX=~/abseil-bin -DBUILD_SHARED_LIBS=${{ matrix.shared-lib }} -DABSL_PROPAGATE_CXX_STD=ON -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded${{ matrix.build-type == 'Debug' && 'Debug' || '' }}${{ matrix.shared-lib == 'ON' && 'DLL' || '' }} -DCMAKE_CXX_STANDARD=17 -S . -B "build"
+          cmake -B build -G "NMake Makefiles" \
+            -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_INSTALL_PREFIX=~/abseil-bin \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
+            -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded${{ matrix.build-type == 'Debug' && 'Debug' || '' }}${{ matrix.shared-lib == 'ON' && 'DLL' || '' }} \
+            -DABSL_PROPAGATE_CXX_STD=ON \
+            -DBUILD_SHARED_LIBS=${{ matrix.shared-lib }} \
+          ;
           cmake --build "build" -j4
           cmake --build "build" --target install
       - name: Build and install protobuf
@@ -160,12 +167,29 @@ jobs:
           cd ~
           git clone --depth=1 https://github.com/protocolbuffers/protobuf.git -b ${{ env.PROTOBUF_VERSION }} protobuf
           cd ~/protobuf
-          cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=~/protobuf-bin -Dprotobuf_BUILD_SHARED_LIBS=${{ matrix.shared-lib }} -DCMAKE_CXX_STANDARD=17 -Dprotobuf_BUILD_EXAMPLES=OFF -Dprotobuf_ABSL_PROVIDER=package -Dabsl_ROOT=~/abseil-bin -DABSL_PROPAGATE_CXX_STD=ON -S . -B "build"
+          cmake -B build -G "NMake Makefiles" \
+            -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_INSTALL_PREFIX=~/protobuf-bin \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
+            -DABSL_PROPAGATE_CXX_STD=ON \
+            -Dabsl_ROOT=~/abseil-bin \
+            -Dprotobuf_ABSL_PROVIDER=package \
+            -Dprotobuf_BUILD_EXAMPLES=OFF \
+            -Dprotobuf_BUILD_SHARED_LIBS=${{ matrix.shared-lib }} \
+            -Dprotobuf_BUILD_TESTS=OFF \
+          ;
           cmake --build "build" -j4
           cmake --build "build" --target install
       - name: Run cmake tests
         run: |
-          cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DBUILD_TESTS=ON -DCMAKE_INSTALL_PREFIX=~/protobuf-c-bin -DBUILD_SHARED_LIBS=${{ matrix.shared-lib }} -DProtobuf_ROOT="~/protobuf-bin" -Dabsl_ROOT="~/abseil-bin" -Dutf8_range_ROOT="~/utf8_range-bin" -S "build-cmake" -B "build"
+          cmake -B build -G "NMake Makefiles" \
+            -DCMAKE_INSTALL_PREFIX=~/protobuf-c-bin \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
+            -DBUILD_TESTS=ON \
+            -DBUILD_SHARED_LIBS=${{ matrix.shared-lib }} \
+            -DProtobuf_ROOT="~/protobuf-bin" \
+            -Dabsl_ROOT="~/abseil-bin" \
+          ;
           cmake --build "build" -j3
           cmake --build "build" --target test
           cmake --build "build" --target install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,13 +125,10 @@ jobs:
     strategy:
       matrix:
         build-type: [Debug, Release]
-        shared-lib: [ON, OFF]
+        shared-lib: [ON]
       fail-fast: false
 
     name: "MSVC CMake (${{ matrix.build-type }}, DLL: ${{ matrix.shared-lib }})"
-
-    env:
-      MSVC_RUNTIME_LIBRARY: "MultiThreaded${{ matrix.build-type == 'Debug' && 'Debug' || '' }}${{ matrix.shared-lib == 'ON' && 'DLL' || '' }}"
 
     steps:
       - uses: ilammy/msvc-dev-cmd@v1
@@ -165,7 +162,6 @@ jobs:
             -DCMAKE_CXX_STANDARD=17 `
             -DCMAKE_INSTALL_PREFIX=~/abseil-bin `
             -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} `
-            -DCMAKE_MSVC_RUNTIME_LIBRARY=${{ env.MSVC_RUNTIME_LIBRARY }} `
             -DABSL_PROPAGATE_CXX_STD=ON `
             -DBUILD_SHARED_LIBS=${{ matrix.shared-lib }} `
           ;
@@ -178,7 +174,6 @@ jobs:
             -DCMAKE_CXX_STANDARD=17 `
             -DCMAKE_INSTALL_PREFIX=~/protobuf-bin `
             -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} `
-            -DCMAKE_MSVC_RUNTIME_LIBRARY=${{ env.MSVC_RUNTIME_LIBRARY }} `
             -DABSL_PROPAGATE_CXX_STD=ON `
             -Dabsl_ROOT=~/abseil-bin `
             -Dprotobuf_ABSL_PROVIDER=package `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,8 +128,8 @@ jobs:
     name: "MSVC CMake (${{ matrix.build-type }}, DLL: ${{ matrix.shared-lib }})"
     runs-on: windows-latest
     env:
-      PROTOBUF_VERSION: 24.3
-      ABSEIL_VERSION: "20230802.0"
+      PROTOBUF_VERSION: "v29.3"
+      ABSEIL_VERSION: "20240722.0"
     steps:
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
@@ -154,20 +154,11 @@ jobs:
           cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_INSTALL_PREFIX=~/abseil-bin -DBUILD_SHARED_LIBS=${{ matrix.shared-lib }} -DABSL_PROPAGATE_CXX_STD=ON -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded${{ matrix.build-type == 'Debug' && 'Debug' || '' }}${{ matrix.shared-lib == 'ON' && 'DLL' || '' }} -DCMAKE_CXX_STANDARD=17 -S . -B "build"
           cmake --build "build" -j4
           cmake --build "build" --target install
-      - name: Build and install utf8 compression algorithm
-        if: matrix.shared-lib == 'OFF'
-        run: |
-          cd ~
-          git clone --depth=1 https://github.com/protocolbuffers/utf8_range.git utf8_range
-          cd ~/utf8_range
-          cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_INSTALL_PREFIX=~/utf8_range-bin -DCMAKE_CXX_STANDARD=17 -Dutf8_range_ENABLE_TESTS=OFF -DBUILD_SHARED_LIBS=OFF -Dabsl_ROOT=~/abseil-bin -DCMAKE_POLICY_DEFAULT_CMP0074=NEW -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY='MultiThreaded${{ matrix.build-type == 'Debug' && 'Debug' || '' }}' -S . -B "build"
-          cmake --build "build" -j4
-          cmake --build "build" --target install
       - name: Build and install protobuf
         if: steps.protobuf-cache.outputs.cache-hit != 'true'
         run: |
           cd ~
-          git clone --depth=1 https://github.com/protocolbuffers/protobuf.git -b v${{ env.PROTOBUF_VERSION }} protobuf
+          git clone --depth=1 https://github.com/protocolbuffers/protobuf.git -b ${{ env.PROTOBUF_VERSION }} protobuf
           cd ~/protobuf && mkdir build && cd build
           cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=~/protobuf-bin -Dprotobuf_BUILD_SHARED_LIBS=${{ matrix.shared-lib }} -DCMAKE_CXX_STANDARD=17 -Dprotobuf_BUILD_EXAMPLES=OFF -Dprotobuf_ABSL_PROVIDER=package -Dabsl_ROOT=~/abseil-bin -DABSL_PROPAGATE_CXX_STD=ON -S . -B "build"
           cmake --build "build" -j4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,7 @@ jobs:
         run: |
           cd ~
           git clone --depth=1 https://github.com/protocolbuffers/protobuf.git -b ${{ env.PROTOBUF_VERSION }} protobuf
-          cd ~/protobuf && mkdir build && cd build
+          cd ~/protobuf
           cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=~/protobuf-bin -Dprotobuf_BUILD_SHARED_LIBS=${{ matrix.shared-lib }} -DCMAKE_CXX_STANDARD=17 -Dprotobuf_BUILD_EXAMPLES=OFF -Dprotobuf_ABSL_PROVIDER=package -Dabsl_ROOT=~/abseil-bin -DABSL_PROPAGATE_CXX_STD=ON -S . -B "build"
           cmake --build "build" -j4
           cmake --build "build" --target install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,18 +135,7 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
         with:
             arch: amd64
-      - uses: actions/cache@v4
-        id: protobuf-cache
-        with:
-          path: ~/protobuf-bin
-          key: ${{ env.PROTOBUF_VERSION }}-${{ matrix.shared-lib }}-${{ matrix.build-type}}
-      - uses: actions/cache@v4
-        id: abseil-cache
-        with:
-          path: ~/abseil-bin
-          key: ${{ env.ABSEIL_VERSION }}-${{ matrix.shared-lib }}-${{ matrix.build-type}}
       - name: Build and install abseil
-        if: steps.abseil-cache.outputs.cache-hit != 'true'
         run: |
           cd ~
           git clone --depth=1 https://github.com/abseil/abseil-cpp.git -b ${{ env.ABSEIL_VERSION }} abseil
@@ -162,7 +151,6 @@ jobs:
           cmake --build "build" -j4
           cmake --build "build" --target install
       - name: Build and install protobuf
-        if: steps.protobuf-cache.outputs.cache-hit != 'true'
         run: |
           cd ~
           git clone --depth=1 https://github.com/protocolbuffers/protobuf.git -b ${{ env.PROTOBUF_VERSION }} protobuf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,9 @@ jobs:
 
     name: "MSVC CMake (${{ matrix.build-type }}, DLL: ${{ matrix.shared-lib }})"
 
+    env:
+      MSVC_RUNTIME_LIBRARY: "MultiThreaded${{ matrix.build-type == 'Debug' && 'Debug' || '' }}${{ matrix.shared-lib == 'ON' && 'DLL' || '' }}"
+
     steps:
       - uses: ilammy/msvc-dev-cmd@v1
         with:
@@ -159,7 +162,7 @@ jobs:
             -DCMAKE_CXX_STANDARD=17 `
             -DCMAKE_INSTALL_PREFIX=~/abseil-bin `
             -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} `
-            -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded${{ matrix.build-type == 'Debug' && 'Debug' || '' }}${{ matrix.shared-lib == 'ON' && 'DLL' || '' }} `
+            -DCMAKE_MSVC_RUNTIME_LIBRARY=${{ env.MSVC_RUNTIME_LIBRARY }} `
             -DABSL_PROPAGATE_CXX_STD=ON `
             -DBUILD_SHARED_LIBS=${{ matrix.shared-lib }} `
           ;
@@ -173,6 +176,7 @@ jobs:
             -DCMAKE_CXX_STANDARD=17 `
             -DCMAKE_INSTALL_PREFIX=~/protobuf-bin `
             -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} `
+            -DCMAKE_MSVC_RUNTIME_LIBRARY=${{ env.MSVC_RUNTIME_LIBRARY }} `
             -DABSL_PROPAGATE_CXX_STD=ON `
             -Dabsl_ROOT=~/abseil-bin `
             -Dprotobuf_ABSL_PROVIDER=package `
@@ -189,6 +193,7 @@ jobs:
           cmake -S build-cmake -B build -G "NMake Makefiles" `
             -DCMAKE_INSTALL_PREFIX=~/protobuf-c-bin `
             -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} `
+            -DCMAKE_MSVC_RUNTIME_LIBRARY=${{ env.MSVC_RUNTIME_LIBRARY }} `
             -DBUILD_TESTS=ON `
             -DBUILD_SHARED_LIBS=${{ matrix.shared-lib }} `
             -DProtobuf_ROOT="~/protobuf-bin" `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,13 +140,13 @@ jobs:
           cd ~
           git clone --depth=1 https://github.com/abseil/abseil-cpp.git -b ${{ env.ABSEIL_VERSION }} abseil
           cd ~/abseil
-          cmake -B build -G "NMake Makefiles" \
-            -DCMAKE_CXX_STANDARD=17 \
-            -DCMAKE_INSTALL_PREFIX=~/abseil-bin \
-            -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
-            -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded${{ matrix.build-type == 'Debug' && 'Debug' || '' }}${{ matrix.shared-lib == 'ON' && 'DLL' || '' }} \
-            -DABSL_PROPAGATE_CXX_STD=ON \
-            -DBUILD_SHARED_LIBS=${{ matrix.shared-lib }} \
+          cmake -B build -G "NMake Makefiles" `
+            -DCMAKE_CXX_STANDARD=17 `
+            -DCMAKE_INSTALL_PREFIX=~/abseil-bin `
+            -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} `
+            -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded${{ matrix.build-type == 'Debug' && 'Debug' || '' }}${{ matrix.shared-lib == 'ON' && 'DLL' || '' }} `
+            -DABSL_PROPAGATE_CXX_STD=ON `
+            -DBUILD_SHARED_LIBS=${{ matrix.shared-lib }} `
           ;
           cmake --build "build" -j4
           cmake --build "build" --target install
@@ -155,29 +155,29 @@ jobs:
           cd ~
           git clone --depth=1 https://github.com/protocolbuffers/protobuf.git -b ${{ env.PROTOBUF_VERSION }} protobuf
           cd ~/protobuf
-          cmake -B build -G "NMake Makefiles" \
-            -DCMAKE_CXX_STANDARD=17 \
-            -DCMAKE_INSTALL_PREFIX=~/protobuf-bin \
-            -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
-            -DABSL_PROPAGATE_CXX_STD=ON \
-            -Dabsl_ROOT=~/abseil-bin \
-            -Dprotobuf_ABSL_PROVIDER=package \
-            -Dprotobuf_BUILD_EXAMPLES=OFF \
-            -Dprotobuf_BUILD_LIBUPB=OFF \
-            -Dprotobuf_BUILD_SHARED_LIBS=${{ matrix.shared-lib }} \
-            -Dprotobuf_BUILD_TESTS=OFF \
+          cmake -B build -G "NMake Makefiles" `
+            -DCMAKE_CXX_STANDARD=17 `
+            -DCMAKE_INSTALL_PREFIX=~/protobuf-bin `
+            -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} `
+            -DABSL_PROPAGATE_CXX_STD=ON `
+            -Dabsl_ROOT=~/abseil-bin `
+            -Dprotobuf_ABSL_PROVIDER=package `
+            -Dprotobuf_BUILD_EXAMPLES=OFF `
+            -Dprotobuf_BUILD_LIBUPB=OFF `
+            -Dprotobuf_BUILD_SHARED_LIBS=${{ matrix.shared-lib }} `
+            -Dprotobuf_BUILD_TESTS=OFF `
           ;
           cmake --build "build" -j4
           cmake --build "build" --target install
       - name: Run cmake tests
         run: |
-          cmake -B build -G "NMake Makefiles" \
-            -DCMAKE_INSTALL_PREFIX=~/protobuf-c-bin \
-            -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
-            -DBUILD_TESTS=ON \
-            -DBUILD_SHARED_LIBS=${{ matrix.shared-lib }} \
-            -DProtobuf_ROOT="~/protobuf-bin" \
-            -Dabsl_ROOT="~/abseil-bin" \
+          cmake -B build -G "NMake Makefiles" `
+            -DCMAKE_INSTALL_PREFIX=~/protobuf-c-bin `
+            -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} `
+            -DBUILD_TESTS=ON `
+            -DBUILD_SHARED_LIBS=${{ matrix.shared-lib }} `
+            -DProtobuf_ROOT="~/protobuf-bin" `
+            -Dabsl_ROOT="~/abseil-bin" `
           ;
           cmake --build "build" -j3
           cmake --build "build" --target test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,6 +175,7 @@ jobs:
             -Dabsl_ROOT=~/abseil-bin \
             -Dprotobuf_ABSL_PROVIDER=package \
             -Dprotobuf_BUILD_EXAMPLES=OFF \
+            -Dprotobuf_BUILD_LIBUPB=OFF \
             -Dprotobuf_BUILD_SHARED_LIBS=${{ matrix.shared-lib }} \
             -Dprotobuf_BUILD_TESTS=OFF \
           ;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,26 +120,41 @@ jobs:
           cmake --build "build" --target install
 
   cmake-msvc:
+    runs-on: windows-latest
+
     strategy:
       matrix:
         build-type: [Debug, Release]
         shared-lib: [ON, OFF]
       fail-fast: false
+
     name: "MSVC CMake (${{ matrix.build-type }}, DLL: ${{ matrix.shared-lib }})"
-    runs-on: windows-latest
-    env:
-      PROTOBUF_VERSION: "v29.3"
-      ABSEIL_VERSION: "20240722.0"
+
     steps:
-      - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
         with:
             arch: amd64
+
+      - name: Checkout protobuf-c
+        uses: actions/checkout@v4
+
+      - name: Checkout abseil
+        uses: actions/checkout@v4
+        with:
+          repository: abseil/abseil-cpp
+          path: "abseil"
+          ref: "20240722.0"
+
+      - name: Checkout protobuf
+        uses: actions/checkout@v4
+        with:
+          repository: protocolbuffers/protobuf
+          path: "protobuf"
+          ref: "v29.3"
+
       - name: Build and install abseil
+        working-directory: "./abseil"
         run: |
-          cd ~
-          git clone --depth=1 https://github.com/abseil/abseil-cpp.git -b ${{ env.ABSEIL_VERSION }} abseil
-          cd ~/abseil
           cmake -B build -G "NMake Makefiles" `
             -DCMAKE_CXX_STANDARD=17 `
             -DCMAKE_INSTALL_PREFIX=~/abseil-bin `
@@ -150,11 +165,10 @@ jobs:
           ;
           cmake --build "build" -j4
           cmake --build "build" --target install
+
       - name: Build and install protobuf
+        working-directory: "./protobuf"
         run: |
-          cd ~
-          git clone --depth=1 https://github.com/protocolbuffers/protobuf.git -b ${{ env.PROTOBUF_VERSION }} protobuf
-          cd ~/protobuf
           cmake -B build -G "NMake Makefiles" `
             -DCMAKE_CXX_STANDARD=17 `
             -DCMAKE_INSTALL_PREFIX=~/protobuf-bin `
@@ -169,6 +183,7 @@ jobs:
           ;
           cmake --build "build" -j4
           cmake --build "build" --target install
+
       - name: Run cmake tests
         run: |
           cmake -B build -G "NMake Makefiles" `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,6 +138,9 @@ jobs:
         with:
             arch: amd64
 
+      - name: Install CMake and Ninja
+        uses: lukka/get-cmake@latest
+
       - name: Checkout protobuf-c
         uses: actions/checkout@v4
 
@@ -158,7 +161,7 @@ jobs:
       - name: Build and install abseil
         working-directory: "./abseil"
         run: |
-          cmake -B build -G "NMake Makefiles" `
+          cmake -B build -G Ninja `
             -DCMAKE_CXX_STANDARD=17 `
             -DCMAKE_INSTALL_PREFIX=~/abseil-bin `
             -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} `
@@ -166,13 +169,12 @@ jobs:
             -DABSL_PROPAGATE_CXX_STD=ON `
             -DBUILD_SHARED_LIBS=${{ matrix.shared-lib }} `
           ;
-          cmake --build "build" -j4
-          cmake --build "build" --target install
+          ninja -C build install
 
       - name: Build and install protobuf
         working-directory: "./protobuf"
         run: |
-          cmake -B build -G "NMake Makefiles" `
+          cmake -B build -G Ninja `
             -DCMAKE_CXX_STANDARD=17 `
             -DCMAKE_INSTALL_PREFIX=~/protobuf-bin `
             -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} `
@@ -185,12 +187,11 @@ jobs:
             -Dprotobuf_BUILD_SHARED_LIBS=${{ matrix.shared-lib }} `
             -Dprotobuf_BUILD_TESTS=OFF `
           ;
-          cmake --build "build" -j4
-          cmake --build "build" --target install
+          ninja -C build install
 
       - name: Build protobuf-c
         run: |
-          cmake -S build-cmake -B build -G "NMake Makefiles" `
+          cmake -S build-cmake -B build -G Ninja `
             -DCMAKE_INSTALL_PREFIX=~/protobuf-c-bin `
             -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} `
             -DCMAKE_MSVC_RUNTIME_LIBRARY=${{ env.MSVC_RUNTIME_LIBRARY }} `
@@ -199,6 +200,6 @@ jobs:
             -DProtobuf_ROOT="~/protobuf-bin" `
             -Dabsl_ROOT="~/abseil-bin" `
           ;
-          cmake --build "build" -j3
+          ninja -C build
           cmake --build "build" --target test
           cmake --build "build" --target install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,6 @@ jobs:
             -DCMAKE_CXX_STANDARD=17 `
             -DCMAKE_INSTALL_PREFIX=~/protobuf-bin `
             -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} `
-            -DABSL_PROPAGATE_CXX_STD=ON `
             -Dabsl_ROOT=~/abseil-bin `
             -Dprotobuf_ABSL_PROVIDER=package `
             -Dprotobuf_BUILD_EXAMPLES=OFF `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,7 +188,6 @@ jobs:
           cmake -S build-cmake -B build -G Ninja `
             -DCMAKE_INSTALL_PREFIX=~/protobuf-c-bin `
             -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} `
-            -DCMAKE_MSVC_RUNTIME_LIBRARY=${{ env.MSVC_RUNTIME_LIBRARY }} `
             -DBUILD_TESTS=ON `
             -DBUILD_SHARED_LIBS=${{ matrix.shared-lib }} `
             -DProtobuf_ROOT="~/protobuf-bin" `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,9 +184,9 @@ jobs:
           cmake --build "build" -j4
           cmake --build "build" --target install
 
-      - name: Run cmake tests
+      - name: Build protobuf-c
         run: |
-          cmake -B build -G "NMake Makefiles" `
+          cmake -S build-cmake -B build -G "NMake Makefiles" `
             -DCMAKE_INSTALL_PREFIX=~/protobuf-c-bin `
             -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} `
             -DBUILD_TESTS=ON `


### PR DESCRIPTION
For MSVC:

- Updated abseil from 20230802.0 to 20240722.0.
- Updated protobuf from 24.3 to 29.3.
- Dropped utf8_range since this appears to have been incorporated into protobuf.