### PR TITLE
cmake: Fix build when using ninja and protobuf-c already installed

### DIFF
--- a/build-cmake/CMakeLists.txt
+++ b/build-cmake/CMakeLists.txt
@@ -157,7 +157,7 @@ if(BUILD_PROTOC)
     COMMAND
       ${CMAKE_COMMAND} -E env PATH="${OS_PATH_VARIABLE}"
       ${PROTOBUF_PROTOC_EXECUTABLE} --cpp_out ${CMAKE_CURRENT_BINARY_DIR}
-      -I${PROTOBUF_INCLUDE_DIR} -I${MAIN_DIR}
+      -I${MAIN_DIR} -I${PROTOBUF_INCLUDE_DIR}
       ${MAIN_DIR}/protobuf-c/protobuf-c.proto
     COMMENT Running
     protoc on ${MAIN_DIR}/protobuf-c/protobuf-c.proto


### PR DESCRIPTION
If protobuf-c is already installed on the system, the cmake build can generate an error like the following when using the ninja backend:

    edmonds@chase{0}:/tmp/protobuf-c$ cmake -S build-cmake -B build -G Ninja
    [...]

    edmonds@chase{0}:/tmp/protobuf-c$ ninja -v -C build
    ninja: Entering directory `build'
    [1/19] cd /tmp/protobuf-c/build && /usr/bin/cmake -E env PATH="/tmp/protobuf-c/build:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/home/edmonds/bin:/home/edmonds/.cargo/bin:/sbin:/bin:/usr/games" /usr/bin/protoc --cpp_out /tmp/protobuf-c/build -I/usr/include -I/tmp/protobuf-c /tmp/protobuf-c/protobuf-c/protobuf-c.proto
    FAILED: CMakeFiles/protoc-generated-files protobuf-c/protobuf-c.pb.cc protobuf-c/protobuf-c.pb.h /tmp/protobuf-c/build/CMakeFiles/protoc-generated-files /tmp/protobuf-c/build/protobuf-c/protobuf-c.pb.cc /tmp/protobuf-c/build/protobuf-c/protobuf-c.pb.h
    cd /tmp/protobuf-c/build && /usr/bin/cmake -E env PATH="/tmp/protobuf-c/build:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/home/edmonds/bin:/home/edmonds/.cargo/bin:/sbin:/bin:/usr/games" /usr/bin/protoc --cpp_out /tmp/protobuf-c/build -I/usr/include -I/tmp/protobuf-c /tmp/protobuf-c/protobuf-c/protobuf-c.proto
    /tmp/protobuf-c/protobuf-c/protobuf-c.proto: Input is shadowed in the --proto_path by "/usr/include/protobuf-c/protobuf-c.proto".  Either use the latter file as your input or reorder the --proto_path so that the former file's location comes first.
    [2/19] /usr/bin/cc -DPACKAGE_STRING="\"protobuf-c 1.5.0\"" -DPACKAGE_VERSION=\"1.5.0\" -I/tmp/protobuf-c -I/tmp/protobuf-c/protobuf-c -I/tmp/protobuf-c/build  -MD -MT CMakeFiles/protobuf-c.dir/tmp/protobuf-c/protobuf-c/protobuf-c.c.o -MF CMakeFiles/protobuf-c.dir/tmp/protobuf-c/protobuf-c/protobuf-c.c.o.d -o CMakeFiles/protobuf-c.dir/tmp/protobuf-c/protobuf-c/protobuf-c.c.o -c /tmp/protobuf-c/protobuf-c/protobuf-c.c
    ninja: build stopped: subcommand failed.