### PR TITLE
Chase compatibility issues with Google protobuf 30.0-rc1

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -102,6 +102,7 @@ protoc_gen_c_protoc_gen_c_SOURCES = \
 	protoc-gen-c/c_service.h \
 	protoc-gen-c/c_string_field.cc \
 	protoc-gen-c/c_string_field.h \
+	protoc-gen-c/compat.h \
 	protobuf-c/protobuf-c.pb.cc \
 	protobuf-c/protobuf-c.pb.h \
 	protoc-gen-c/main.cc

--- a/protoc-gen-c/c_enum.cc
+++ b/protoc-gen-c/c_enum.cc
@@ -152,7 +152,7 @@ void EnumGenerator::GenerateValueInitializer(google::protobuf::io::Printer *prin
     descriptor_->file()->options().optimize_for() ==
     google::protobuf::FileOptions_OptimizeMode_CODE_SIZE;
   vars["enum_value_name"] = vd->name();
-  vars["c_enum_value_name"] = FullNameToUpper(descriptor_->full_name(), descriptor_->file()) + "__" + vd->name();
+  vars["c_enum_value_name"] = FullNameToUpper(descriptor_->full_name(), descriptor_->file()) + "__" + std::string(vd->name());
   vars["value"] = SimpleItoa(vd->number());
   if (optimize_code_size)
     printer->Print(vars, "  { NULL, NULL, $value$ }, /* CODE_SIZE */\n");

--- a/protoc-gen-c/c_enum.cc
+++ b/protoc-gen-c/c_enum.cc
@@ -195,14 +195,9 @@ void EnumGenerator::GenerateEnumDescriptor(google::protobuf::io::Printer* printe
   // Sort by name and value, dropping duplicate values if they appear later.
   // TODO: use a c++ paradigm for this!
   std::vector<ValueIndex> value_index;
-  for (unsigned j = 0; j < descriptor_->value_count(); j++) {
+  for (int j = 0; j < descriptor_->value_count(); j++) {
     const google::protobuf::EnumValueDescriptor *vd = descriptor_->value(j);
-    value_index.push_back({
-      .value = vd->number(),
-      .index = j,
-      .final_index = 0,
-      .name = vd->name(),
-    });
+    value_index.push_back({ vd->number(), (unsigned)j, 0, vd->name() });
   }
   qsort(&value_index[0],
         value_index.size(),

--- a/protoc-gen-c/c_enum.cc
+++ b/protoc-gen-c/c_enum.cc
@@ -142,7 +142,7 @@ struct ValueIndex
   int value;
   unsigned index;
   unsigned final_index;		/* index in uniqified array of values */
-  const char *name;
+  compat::StringView name;
 };
 void EnumGenerator::GenerateValueInitializer(google::protobuf::io::Printer *printer, int index)
 {
@@ -176,7 +176,7 @@ static int compare_value_indices_by_name(const void *a, const void *b)
 {
   const ValueIndex *vi_a = (const ValueIndex *) a;
   const ValueIndex *vi_b = (const ValueIndex *) b;
-  return strcmp (vi_a->name, vi_b->name);
+  return vi_a->name.compare(vi_b->name);
 }
 
 void EnumGenerator::GenerateEnumDescriptor(google::protobuf::io::Printer* printer) {
@@ -194,18 +194,20 @@ void EnumGenerator::GenerateEnumDescriptor(google::protobuf::io::Printer* printe
 
   // Sort by name and value, dropping duplicate values if they appear later.
   // TODO: use a c++ paradigm for this!
-  NameIndex *name_index = new NameIndex[descriptor_->value_count()];
-  ValueIndex *value_index = new ValueIndex[descriptor_->value_count()];
-  for (int j = 0; j < descriptor_->value_count(); j++) {
+  std::vector<ValueIndex> value_index;
+  for (unsigned j = 0; j < descriptor_->value_count(); j++) {
     const google::protobuf::EnumValueDescriptor *vd = descriptor_->value(j);
-    name_index[j].index = j;
-    name_index[j].name = vd->name().c_str();
-    value_index[j].index = j;
-    value_index[j].value = vd->number();
-    value_index[j].name = vd->name().c_str();
+    value_index.push_back({
+      .value = vd->number(),
+      .index = j,
+      .final_index = 0,
+      .name = vd->name(),
+    });
   }
-  qsort(value_index, descriptor_->value_count(),
-	sizeof(ValueIndex), compare_value_indices_by_value_then_index);
+  qsort(&value_index[0],
+        value_index.size(),
+        sizeof(ValueIndex),
+        compare_value_indices_by_value_then_index);
 
   // only record unique values
   int n_unique_values;
@@ -275,8 +277,10 @@ void EnumGenerator::GenerateEnumDescriptor(google::protobuf::io::Printer* printe
   vars["n_ranges"] = SimpleItoa(n_ranges);
 
   if (!optimize_code_size) {
-    qsort(value_index, descriptor_->value_count(),
-        sizeof(ValueIndex), compare_value_indices_by_name);
+    qsort(&value_index[0],
+          value_index.size(),
+          sizeof(ValueIndex),
+          compare_value_indices_by_name);
     printer->Print(vars,
         "static const ProtobufCEnumValueIndex $lcclassname$__enum_values_by_name[$value_count$] =\n"
         "{\n");
@@ -319,9 +323,6 @@ void EnumGenerator::GenerateEnumDescriptor(google::protobuf::io::Printer* printe
         "  NULL,NULL,NULL,NULL   /* reserved[1234] */\n"
         "};\n");
   }
-
-  delete[] value_index;
-  delete[] name_index;
 }
 
 }  // namespace protobuf_c

--- a/protoc-gen-c/c_enum_field.cc
+++ b/protoc-gen-c/c_enum_field.cc
@@ -78,7 +78,7 @@ void SetEnumVariables(const google::protobuf::FieldDescriptor* descriptor,
   (*variables)["type"] = FullNameToC(descriptor->enum_type()->full_name(), descriptor->enum_type()->file());
   const google::protobuf::EnumValueDescriptor* default_value = descriptor->default_value_enum();
   (*variables)["default"] = FullNameToUpper(default_value->type()->full_name(), default_value->type()->file())
-                          + "__" + default_value->name();
+                          + "__" + std::string(default_value->name());
   (*variables)["deprecated"] = FieldDeprecated(descriptor);
 }
 

--- a/protoc-gen-c/c_field.cc
+++ b/protoc-gen-c/c_field.cc
@@ -74,6 +74,7 @@
 #include "c_message_field.h"
 #include "c_primitive_field.h"
 #include "c_string_field.h"
+#include "compat.h"
 
 namespace protobuf_c {
 

--- a/protoc-gen-c/c_helpers.cc
+++ b/protoc-gen-c/c_helpers.cc
@@ -261,7 +261,7 @@ int compare_name_indices_by_name(const void *a, const void *b)
 {
   const NameIndex *ni_a = (const NameIndex *) a;
   const NameIndex *ni_b = (const NameIndex *) b;
-  return strcmp (ni_a->name, ni_b->name);
+  return ni_a->name.compare(ni_b->name);
 }
 
 std::string CEscape(compat::StringView src);

--- a/protoc-gen-c/c_helpers.cc
+++ b/protoc-gen-c/c_helpers.cc
@@ -90,14 +90,6 @@ namespace protobuf_c {
 #pragma warning(disable:4996)
 #endif
 
-std::string DotsToUnderscores(const std::string& name) {
-  return StringReplace(name, ".", "_", true);
-}
-
-std::string DotsToColons(const std::string& name) {
-  return StringReplace(name, ".", "::", true);
-}
-
 std::string SimpleFtoa(float f) {
   char buf[100];
   snprintf(buf,sizeof(buf),"%.*g", FLT_DIG, f);
@@ -333,11 +325,6 @@ std::string FilenameIdentifier(const std::string& filename) {
   return result;
 }
 
-// Return the name of the BuildDescriptors() function for a given file.
-std::string GlobalBuildDescriptorsName(const std::string& filename) {
-  return "proto_BuildDescriptors_" + FilenameIdentifier(filename);
-}
-
 std::string GetLabelName(google::protobuf::FieldDescriptor::Label label) {
   switch (label) {
     case google::protobuf::FieldDescriptor::LABEL_OPTIONAL: return "optional";
@@ -392,57 +379,6 @@ WriteIntRanges(google::protobuf::io::Printer* printer, int n_values, const int *
   }
 }
     
-
-
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXx
-// XXXXXXXXX  this stuff is copied from strutils.cc !!!!   XXXXXXXXXXXXXXXXXXXXXXXXXXXXx
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXx
-// ----------------------------------------------------------------------
-// StringReplace()
-//    Replace the "old" pattern with the "new" pattern in a string,
-//    and append the result to "res".  If replace_all is false,
-//    it only replaces the first instance of "old."
-// ----------------------------------------------------------------------
-
-void StringReplace(const std::string& s, const std::string& oldsub,
-                   const std::string& newsub, bool replace_all,
-                   std::string* res) {
-  if (oldsub.empty()) {
-    res->append(s);  // if empty, append the given string.
-    return;
-  }
-
-  std::string::size_type start_pos = 0;
-  std::string::size_type pos;
-  do {
-    pos = s.find(oldsub, start_pos);
-    if (pos == std::string::npos) {
-      break;
-    }
-    res->append(s, start_pos, pos - start_pos);
-    res->append(newsub);
-    start_pos = pos + oldsub.size();  // start searching again after the "old"
-  } while (replace_all);
-  res->append(s, start_pos, s.length() - start_pos);
-}
-
-
-// ----------------------------------------------------------------------
-// StringReplace()
-//    Give me a string and two patterns "old" and "new", and I replace
-//    the first instance of "old" in the string with "new", if it
-//    exists.  If "global" is true; call this repeatedly until it
-//    fails.  RETURN a new string, regardless of whether the replacement
-//    happened or not.
-// ----------------------------------------------------------------------
-
-std::string StringReplace(const std::string& s, const std::string& oldsub,
-                          const std::string& newsub, bool replace_all) {
-  std::string ret;
-  StringReplace(s, oldsub, newsub, replace_all, &ret);
-  return ret;
-}
-
 // ----------------------------------------------------------------------
 // SplitStringUsing()
 //    Split a string using a character delimiter. Append the components

--- a/protoc-gen-c/c_helpers.cc
+++ b/protoc-gen-c/c_helpers.cc
@@ -178,13 +178,13 @@ std::string ToCamel(compat::StringView name) {
 std::string OverrideFullName(compat::StringView full_name, const google::protobuf::FileDescriptor* file) {
   const ProtobufCFileOptions opt = file->options().GetExtension(pb_c_file);
   if (!opt.has_c_package())
-    return full_name;
+    return std::string(full_name);
 
   std::string new_name = opt.c_package();
   if (file->package().empty())
     new_name += ".";
 
-  return new_name + full_name.substr(file->package().length());
+  return new_name + std::string(full_name.substr(file->package().length()));
 }
 
 std::string FullNameToLower(compat::StringView full_name, const google::protobuf::FileDescriptor* file) {
@@ -418,10 +418,10 @@ void SplitStringToIteratorUsing(compat::StringView full,
   while (begin_index != std::string::npos) {
     end_index = full.find_first_of(delim, begin_index);
     if (end_index == std::string::npos) {
-      *result++ = full.substr(begin_index);
+      *result++ = std::string(full.substr(begin_index));
       return;
     }
-    *result++ = full.substr(begin_index, (end_index - begin_index));
+    *result++ = std::string(full.substr(begin_index, (end_index - begin_index)));
     begin_index = full.find_first_not_of(delim, end_index);
   }
 }

--- a/protoc-gen-c/c_helpers.cc
+++ b/protoc-gen-c/c_helpers.cc
@@ -96,6 +96,7 @@ std::string SimpleFtoa(float f) {
   buf[sizeof(buf)-1] = 0;		/* should NOT be necessary */
   return buf;
 }
+
 std::string SimpleDtoa(double d) {
   char buf[100];
   snprintf(buf,sizeof(buf),"%.*g", DBL_DIG, d);
@@ -103,7 +104,7 @@ std::string SimpleDtoa(double d) {
   return buf;
 }
 
-std::string CamelToUpper(const std::string &name) {
+std::string CamelToUpper(compat::StringView name) {
   bool was_upper = true;		// suppress initial _
   std::string rv = "";
   int len = name.length();
@@ -120,7 +121,8 @@ std::string CamelToUpper(const std::string &name) {
   }
   return rv;
 }
-std::string CamelToLower(const std::string &name) {
+
+std::string CamelToLower(compat::StringView name) {
   bool was_upper = true;		// suppress initial _
   std::string rv = "";
   int len = name.length();
@@ -138,8 +140,7 @@ std::string CamelToLower(const std::string &name) {
   return rv;
 }
 
-
-std::string ToUpper(const std::string &name) {
+std::string ToUpper(compat::StringView name) {
   std::string rv = "";
   int len = name.length();
   for (int i = 0; i < len; i++) {
@@ -147,7 +148,8 @@ std::string ToUpper(const std::string &name) {
   }
   return rv;
 }
-std::string ToLower(const std::string &name) {
+
+std::string ToLower(compat::StringView name) {
   std::string rv = "";
   int len = name.length();
   for (int i = 0; i < len; i++) {
@@ -155,7 +157,8 @@ std::string ToLower(const std::string &name) {
   }
   return rv;
 }
-std::string ToCamel(const std::string &name) {
+
+std::string ToCamel(compat::StringView name) {
   std::string rv = "";
   int len = name.length();
   bool next_is_upper = true;
@@ -172,7 +175,7 @@ std::string ToCamel(const std::string &name) {
   return rv;
 }
 
-std::string OverrideFullName(const std::string &full_name, const google::protobuf::FileDescriptor* file) {
+std::string OverrideFullName(compat::StringView full_name, const google::protobuf::FileDescriptor* file) {
   const ProtobufCFileOptions opt = file->options().GetExtension(pb_c_file);
   if (!opt.has_c_package())
     return full_name;
@@ -184,7 +187,7 @@ std::string OverrideFullName(const std::string &full_name, const google::protobu
   return new_name + full_name.substr(file->package().length());
 }
 
-std::string FullNameToLower(const std::string &full_name, const google::protobuf::FileDescriptor* file) {
+std::string FullNameToLower(compat::StringView full_name, const google::protobuf::FileDescriptor* file) {
   std::vector<std::string> pieces;
   SplitStringUsing(OverrideFullName(full_name, file), ".", &pieces);
   std::string rv = "";
@@ -195,7 +198,8 @@ std::string FullNameToLower(const std::string &full_name, const google::protobuf
   }
   return rv;
 }
-std::string FullNameToUpper(const std::string &full_name, const google::protobuf::FileDescriptor* file) {
+
+std::string FullNameToUpper(compat::StringView full_name, const google::protobuf::FileDescriptor* file) {
   std::vector<std::string> pieces;
   SplitStringUsing(OverrideFullName(full_name, file), ".", &pieces);
   std::string rv = "";
@@ -206,7 +210,8 @@ std::string FullNameToUpper(const std::string &full_name, const google::protobuf
   }
   return rv;
 }
-std::string FullNameToC(const std::string &full_name, const google::protobuf::FileDescriptor* file) {
+
+std::string FullNameToC(compat::StringView full_name, const google::protobuf::FileDescriptor* file) {
   std::vector<std::string> pieces;
   SplitStringUsing(OverrideFullName(full_name, file), ".", &pieces);
   std::string rv = "";
@@ -248,7 +253,7 @@ void PrintComment(google::protobuf::io::Printer* printer, std::string comment)
    }
 }
 
-std::string ConvertToSpaces(const std::string &input) {
+std::string ConvertToSpaces(compat::StringView input) {
   return std::string(input.size(), ' ');
 }
 
@@ -259,8 +264,7 @@ int compare_name_indices_by_name(const void *a, const void *b)
   return strcmp (ni_a->name, ni_b->name);
 }
 
-
-std::string CEscape(const std::string& src);
+std::string CEscape(compat::StringView src);
 
 const char* const kKeywordList[] = {
   "and", "and_eq", "asm", "auto", "bitand", "bitor", "bool", "break", "case",
@@ -300,7 +304,7 @@ std::string FieldDeprecated(const google::protobuf::FieldDescriptor* field) {
   return "";
 }
 
-std::string StripProto(const std::string& filename) {
+std::string StripProto(compat::StringView filename) {
   if (HasSuffixString(filename, ".protodevel")) {
     return StripSuffixString(filename, ".protodevel");
   } else {
@@ -309,7 +313,7 @@ std::string StripProto(const std::string& filename) {
 }
 
 // Convert a file name into a valid identifier.
-std::string FilenameIdentifier(const std::string& filename) {
+std::string FilenameIdentifier(compat::StringView filename) {
   std::string result;
   for (unsigned i = 0; i < filename.size(); i++) {
     if (isalnum(filename[i])) {
@@ -335,7 +339,7 @@ std::string GetLabelName(google::protobuf::FieldDescriptor::Label label) {
 }
 
 unsigned
-WriteIntRanges(google::protobuf::io::Printer* printer, int n_values, const int *values, const std::string &name)
+WriteIntRanges(google::protobuf::io::Printer* printer, int n_values, const int *values, compat::StringView name)
 {
   std::map<std::string, std::string> vars;
   vars["name"] = name;
@@ -389,7 +393,7 @@ WriteIntRanges(google::protobuf::io::Printer* printer, int n_values, const int *
 // ----------------------------------------------------------------------
 template <typename ITR>
 static inline
-void SplitStringToIteratorUsing(const std::string& full,
+void SplitStringToIteratorUsing(compat::StringView full,
                                 const char* delim,
                                 ITR& result) {
   // Optimize the common case where delim is a single character.
@@ -422,7 +426,7 @@ void SplitStringToIteratorUsing(const std::string& full,
   }
 }
 
-void SplitStringUsing(const std::string& full,
+void SplitStringUsing(compat::StringView full,
                       const char* delim,
                       std::vector<std::string>* result) {
   std::back_insert_iterator< std::vector<std::string> > it(*result);
@@ -434,7 +438,6 @@ char* FastHexToBuffer(int i, char* buffer)
   snprintf(buffer, 16, "%x", i);
   return buffer;
 }
-
 
 static int CEscapeInternal(const char* src, int src_len, char* dest,
                            int dest_len, bool use_hex) {
@@ -478,7 +481,8 @@ static int CEscapeInternal(const char* src, int src_len, char* dest,
   dest[used] = '\0';   // doesn't count towards return value though
   return used;
 }
-std::string CEscape(const std::string& src) {
+
+std::string CEscape(compat::StringView src) {
   const int dest_length = src.size() * 4 + 1; // Maximum possible expansion
   std::unique_ptr<char[]> dest(new char[dest_length]);
   const int len = CEscapeInternal(src.data(), src.size(),

--- a/protoc-gen-c/c_helpers.cc
+++ b/protoc-gen-c/c_helpers.cc
@@ -73,6 +73,7 @@
 #include <google/protobuf/stubs/common.h>
 
 #include "c_helpers.h"
+#include "compat.h"
 
 namespace protobuf_c {
 

--- a/protoc-gen-c/c_helpers.h
+++ b/protoc-gen-c/c_helpers.h
@@ -89,9 +89,8 @@ std::string SimpleDtoa(double f);
 void SplitStringUsing(compat::StringView str, const char *delim, std::vector<std::string> *out);
 std::string CEscape(compat::StringView src);
 inline bool HasSuffixString(compat::StringView str, compat::StringView suffix) { return str.size() >= suffix.size() && str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0; }
-inline std::string StripSuffixString(compat::StringView str, compat::StringView suffix) { if (HasSuffixString(str, suffix)) { return str.substr(0, str.size() - suffix.size()); } else { return str; } }
+inline std::string StripSuffixString(compat::StringView str, compat::StringView suffix) { if (HasSuffixString(str, suffix)) { return std::string(str.substr(0, str.size() - suffix.size())); } else { return std::string(str); } }
 char* FastHexToBuffer(int i, char* buffer);
-
 
 // Get the (unqualified) name that should be used for this field in C code.
 // The name is coerced to lower-case to emulate proto1 behavior.  People

--- a/protoc-gen-c/c_helpers.h
+++ b/protoc-gen-c/c_helpers.h
@@ -73,6 +73,8 @@
 
 #include <protobuf-c/protobuf-c.pb.h>
 
+#include "compat.h"
+
 namespace protobuf_c {
 
 // --- Borrowed from stubs. ---
@@ -84,11 +86,10 @@ template <typename T> std::string SimpleItoa(T n) {
 
 std::string SimpleFtoa(float f);
 std::string SimpleDtoa(double f);
-void SplitStringUsing(const std::string &str, const char *delim, std::vector<std::string> *out);
-std::string CEscape(const std::string& src);
-std::string StringReplace(const std::string& s, const std::string& oldsub, const std::string& newsub, bool replace_all);
-inline bool HasSuffixString(const std::string& str, const std::string& suffix) { return str.size() >= suffix.size() && str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0; }
-inline std::string StripSuffixString(const std::string& str, const std::string& suffix) { if (HasSuffixString(str, suffix)) { return str.substr(0, str.size() - suffix.size()); } else { return str; } }
+void SplitStringUsing(compat::StringView str, const char *delim, std::vector<std::string> *out);
+std::string CEscape(compat::StringView src);
+inline bool HasSuffixString(compat::StringView str, compat::StringView suffix) { return str.size() >= suffix.size() && str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0; }
+inline std::string StripSuffixString(compat::StringView str, compat::StringView suffix) { if (HasSuffixString(str, suffix)) { return str.substr(0, str.size() - suffix.size()); } else { return str; } }
 char* FastHexToBuffer(int i, char* buffer);
 
 
@@ -110,31 +111,31 @@ inline const google::protobuf::Descriptor* FieldScope(const google::protobuf::Fi
 
 // convert a CamelCase class name into an all uppercase affair
 // with underscores separating words, e.g. MyClass becomes MY_CLASS.
-std::string CamelToUpper(const std::string &class_name);
-std::string CamelToLower(const std::string &class_name);
+std::string CamelToUpper(compat::StringView class_name);
+std::string CamelToLower(compat::StringView class_name);
 
 // lowercased, underscored name to camel case
-std::string ToCamel(const std::string &name);
+std::string ToCamel(compat::StringView name);
 
 // lowercase the string
-std::string ToLower(const std::string &class_name);
-std::string ToUpper(const std::string &class_name);
+std::string ToLower(compat::StringView class_name);
+std::string ToUpper(compat::StringView class_name);
 
 // full_name() to lowercase with underscores
-std::string FullNameToLower(const std::string &full_name, const google::protobuf::FileDescriptor *file);
-std::string FullNameToUpper(const std::string &full_name, const google::protobuf::FileDescriptor *file);
+std::string FullNameToLower(compat::StringView full_name, const google::protobuf::FileDescriptor *file);
+std::string FullNameToUpper(compat::StringView full_name, const google::protobuf::FileDescriptor *file);
 
 // full_name() to c-typename (with underscores for packages, otherwise camel case)
-std::string FullNameToC(const std::string &class_name, const google::protobuf::FileDescriptor *file);
+std::string FullNameToC(compat::StringView class_name, const google::protobuf::FileDescriptor *file);
 
 // Splits, indents, formats, and prints comment lines
 void PrintComment(google::protobuf::io::Printer* printer, std::string comment);
 
 // make a string of spaces as long as input
-std::string ConvertToSpaces(const std::string &input);
+std::string ConvertToSpaces(compat::StringView input);
 
 // Strips ".proto" or ".protodevel" from the end of a filename.
-std::string StripProto(const std::string& filename);
+std::string StripProto(compat::StringView filename);
 
 // Get the C++ type name for a primitive type (e.g. "double", "::google::protobuf::int32", etc.).
 // Note:  non-built-in type names will be qualified, meaning they will start
@@ -148,15 +149,14 @@ const char* PrimitiveTypeName(google::protobuf::FieldDescriptor::CppType type);
 const char* DeclaredTypeMethodName(google::protobuf::FieldDescriptor::Type type);
 
 // Convert a file name into a valid identifier.
-std::string FilenameIdentifier(const std::string& filename);
+std::string FilenameIdentifier(compat::StringView filename);
 
 // return 'required', 'optional', or 'repeated'
 std::string GetLabelName(google::protobuf::FieldDescriptor::Label label);
 
-
 // write IntRanges entries for a bunch of sorted values.
 // returns the number of ranges there are to bsearch.
-unsigned WriteIntRanges(google::protobuf::io::Printer* printer, int n_values, const int *values, const std::string &name);
+unsigned WriteIntRanges(google::protobuf::io::Printer* printer, int n_values, const int *values, compat::StringView name);
 
 struct NameIndex
 {

--- a/protoc-gen-c/c_helpers.h
+++ b/protoc-gen-c/c_helpers.h
@@ -150,9 +150,6 @@ const char* DeclaredTypeMethodName(google::protobuf::FieldDescriptor::Type type)
 // Convert a file name into a valid identifier.
 std::string FilenameIdentifier(const std::string& filename);
 
-// Return the name of the BuildDescriptors() function for a given file.
-std::string GlobalBuildDescriptorsName(const std::string& filename);
-
 // return 'required', 'optional', or 'repeated'
 std::string GetLabelName(google::protobuf::FieldDescriptor::Label label);
 

--- a/protoc-gen-c/c_helpers.h
+++ b/protoc-gen-c/c_helpers.h
@@ -186,16 +186,6 @@ inline int FieldSyntax(const google::protobuf::FieldDescriptor* field) {
   return 2;
 }
 
-// Work around changes in protobuf >= 22.x without breaking compilation against
-// older protobuf versions.
-#if GOOGLE_PROTOBUF_VERSION >= 4022000
-# define GOOGLE_ARRAYSIZE	ABSL_ARRAYSIZE
-# define GOOGLE_CHECK_EQ	ABSL_CHECK_EQ
-# define GOOGLE_CHECK_EQ	ABSL_CHECK_EQ
-# define GOOGLE_DCHECK_GE	ABSL_DCHECK_GE
-# define GOOGLE_LOG		ABSL_LOG
-#endif
-
 }  // namespace protobuf_c
 
 #endif  // PROTOBUF_C_PROTOC_GEN_C_C_HELPERS_H__

--- a/protoc-gen-c/c_helpers.h
+++ b/protoc-gen-c/c_helpers.h
@@ -160,7 +160,7 @@ unsigned WriteIntRanges(google::protobuf::io::Printer* printer, int n_values, co
 struct NameIndex
 {
   unsigned index;
-  const char *name;
+  compat::StringView name;
 };
 int compare_name_indices_by_name(const void*, const void*);
 

--- a/protoc-gen-c/c_message.cc
+++ b/protoc-gen-c/c_message.cc
@@ -78,6 +78,7 @@
 #include "c_extension.h"
 #include "c_helpers.h"
 #include "c_message.h"
+#include "compat.h"
 
 namespace protobuf_c {
 

--- a/protoc-gen-c/c_message.cc
+++ b/protoc-gen-c/c_message.cc
@@ -581,7 +581,7 @@ GenerateMessageDescriptor(google::protobuf::io::Printer* printer, bool gen_init)
     if (!optimize_code_size) {
       std::vector<NameIndex> field_indices;
       for (unsigned i = 0; i < descriptor_->field_count(); i++) {
-        field_indices.push_back({ .index = i, .name = sorted_fields[i]->name() });
+        field_indices.push_back({ i, sorted_fields[i]->name() });
       }
       qsort(&field_indices[0],
             field_indices.size(),

--- a/protoc-gen-c/c_primitive_field.cc
+++ b/protoc-gen-c/c_primitive_field.cc
@@ -67,6 +67,7 @@
 
 #include "c_helpers.h"
 #include "c_primitive_field.h"
+#include "compat.h"
 
 namespace protobuf_c {
 

--- a/protoc-gen-c/compat.h
+++ b/protoc-gen-c/compat.h
@@ -28,6 +28,8 @@
 #ifndef PROTOBUF_C_PROTOC_GEN_C_COMPAT_H__
 #define PROTOBUF_C_PROTOC_GEN_C_COMPAT_H__
 
+#include <string>
+
 #if GOOGLE_PROTOBUF_VERSION >= 4022000
 # define GOOGLE_ARRAYSIZE	ABSL_ARRAYSIZE
 # define GOOGLE_CHECK_EQ	ABSL_CHECK_EQ
@@ -38,6 +40,12 @@
 namespace protobuf_c {
 
 namespace compat {
+
+#if GOOGLE_PROTOBUF_VERSION >= 6030000
+typedef google::protobuf::internal::DescriptorStringView StringView;
+#else
+typedef const std::string& StringView;
+#endif
 
 }  // namespace compat
 

--- a/protoc-gen-c/compat.h
+++ b/protoc-gen-c/compat.h
@@ -25,29 +25,22 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <string>
+#ifndef PROTOBUF_C_PROTOC_GEN_C_COMPAT_H__
+#define PROTOBUF_C_PROTOC_GEN_C_COMPAT_H__
 
-#include <google/protobuf/compiler/command_line_interface.h>
-#include <google/protobuf/compiler/plugin.h>
+#if GOOGLE_PROTOBUF_VERSION >= 4022000
+# define GOOGLE_ARRAYSIZE	ABSL_ARRAYSIZE
+# define GOOGLE_CHECK_EQ	ABSL_CHECK_EQ
+# define GOOGLE_DCHECK_GE	ABSL_DCHECK_GE
+# define GOOGLE_LOG		ABSL_LOG
+#endif
 
-#include "c_generator.h"
-#include "c_helpers.h"
-#include "compat.h"
+namespace protobuf_c {
 
-int main(int argc, char* argv[]) {
-  protobuf_c::CGenerator c_generator;
+namespace compat {
 
-  std::string invocation_name = argv[0];
-  std::string invocation_basename = invocation_name.substr(invocation_name.find_last_of("/") + 1);
-  const std::string standalone_name = "protoc-c";
+}  // namespace compat
 
-  if (invocation_basename == standalone_name) {
-    GOOGLE_LOG(WARNING) << "`protoc-c` is deprecated. Please use `protoc` instead!";
-    google::protobuf::compiler::CommandLineInterface cli;
-    cli.RegisterGenerator("--c_out", &c_generator, "Generate C/H files.");
-    cli.SetVersionInfo(PACKAGE_STRING);
-    return cli.Run(argc, argv);
-  }
+}  // namespace protobuf_c
 
-  return google::protobuf::compiler::PluginMain(argc, argv, &c_generator);
-}
+#endif  // PROTOBUF_C_PROTOC_GEN_C_COMPAT_H__

--- a/protoc-gen-c/compat.h
+++ b/protoc-gen-c/compat.h
@@ -37,12 +37,16 @@
 # define GOOGLE_LOG		ABSL_LOG
 #endif
 
+#if GOOGLE_PROTOBUF_VERSION >= 6030000
+# include <absl/strings/string_view.h>
+#endif
+
 namespace protobuf_c {
 
 namespace compat {
 
 #if GOOGLE_PROTOBUF_VERSION >= 6030000
-typedef google::protobuf::internal::DescriptorStringView StringView;
+typedef absl::string_view StringView;
 #else
 typedef const std::string& StringView;
 #endif

--- a/protoc-gen-c/compat.h
+++ b/protoc-gen-c/compat.h
@@ -28,8 +28,6 @@
 #ifndef PROTOBUF_C_PROTOC_GEN_C_COMPAT_H__
 #define PROTOBUF_C_PROTOC_GEN_C_COMPAT_H__
 
-#include <string>
-
 #if GOOGLE_PROTOBUF_VERSION >= 4022000
 # define GOOGLE_ARRAYSIZE	ABSL_ARRAYSIZE
 # define GOOGLE_CHECK_EQ	ABSL_CHECK_EQ
@@ -39,6 +37,8 @@
 
 #if GOOGLE_PROTOBUF_VERSION >= 6030000
 # include <absl/strings/string_view.h>
+#else
+# include <string>
 #endif
 
 namespace protobuf_c {


### PR DESCRIPTION
protobuf 30 (https://github.com/protocolbuffers/protobuf/releases/tag/v30.0-rc1) breaks the build of protobuf-c <= 1.5.1 due to the change of various return types away from `const std::string&` for returning string views:

> v30 will update return types in descriptor (such as full_name) to be absl::string_view.

https://protobuf.dev/news/2024-10-02/#descriptor-apis

This branch replaces various uses of `const char *` and `const std::string&` with our own `compat::StringView` typedef that handles the `const std::string&` change across the multiple versions of protobuf that protobuf-c supports.

Some extremely old code was using new/delete to allocate arrays of objects that previously were storing `const char *`'s. That code was updated to use `std::vector`.

Some internal functions that are not used anywhere in the protobuf-c code base were removed.