### PR TITLE
protoc-gen-c: Explicitly construct strings where needed for protobuf 30.x

### DIFF
--- a/protoc-gen-c/c_enum.cc
+++ b/protoc-gen-c/c_enum.cc
@@ -81,7 +81,7 @@ EnumGenerator::~EnumGenerator() {}
 void EnumGenerator::GenerateDefinition(google::protobuf::io::Printer* printer) {
   std::map<std::string, std::string> vars;
   vars["classname"] = FullNameToC(descriptor_->full_name(), descriptor_->file());
-  vars["shortname"] = descriptor_->name();
+  vars["shortname"] = std::string(descriptor_->name());
   vars["uc_name"] = FullNameToUpper(descriptor_->full_name(), descriptor_->file());
 
   google::protobuf::SourceLocation sourceLoc;
@@ -98,7 +98,7 @@ void EnumGenerator::GenerateDefinition(google::protobuf::io::Printer* printer) {
   vars["opt_comma"] = ",";
   vars["prefix"] = FullNameToUpper(descriptor_->full_name(), descriptor_->file()) + "__";
   for (int i = 0; i < descriptor_->value_count(); i++) {
-    vars["name"] = descriptor_->value(i)->name();
+    vars["name"] = std::string(descriptor_->value(i)->name());
     vars["number"] = SimpleItoa(descriptor_->value(i)->number());
     if (i + 1 == descriptor_->value_count())
       vars["opt_comma"] = "";
@@ -151,7 +151,7 @@ void EnumGenerator::GenerateValueInitializer(google::protobuf::io::Printer *prin
   bool optimize_code_size = descriptor_->file()->options().has_optimize_for() &&
     descriptor_->file()->options().optimize_for() ==
     google::protobuf::FileOptions_OptimizeMode_CODE_SIZE;
-  vars["enum_value_name"] = vd->name();
+  vars["enum_value_name"] = std::string(vd->name());
   vars["c_enum_value_name"] = FullNameToUpper(descriptor_->full_name(), descriptor_->file()) + "__" + std::string(vd->name());
   vars["value"] = SimpleItoa(vd->number());
   if (optimize_code_size)
@@ -181,11 +181,11 @@ static int compare_value_indices_by_name(const void *a, const void *b)
 
 void EnumGenerator::GenerateEnumDescriptor(google::protobuf::io::Printer* printer) {
   std::map<std::string, std::string> vars;
-  vars["fullname"] = descriptor_->full_name();
+  vars["fullname"] = std::string(descriptor_->full_name());
   vars["lcclassname"] = FullNameToLower(descriptor_->full_name(), descriptor_->file());
   vars["cname"] = FullNameToC(descriptor_->full_name(), descriptor_->file());
-  vars["shortname"] = descriptor_->name();
-  vars["packagename"] = descriptor_->file()->package();
+  vars["shortname"] = std::string(descriptor_->name());
+  vars["packagename"] = std::string(descriptor_->file()->package());
   vars["value_count"] = SimpleItoa(descriptor_->value_count());
 
   bool optimize_code_size = descriptor_->file()->options().has_optimize_for() &&
@@ -281,7 +281,7 @@ void EnumGenerator::GenerateEnumDescriptor(google::protobuf::io::Printer* printe
         "{\n");
     for (int j = 0; j < descriptor_->value_count(); j++) {
       vars["index"] = SimpleItoa(value_index[j].final_index);
-      vars["name"] = value_index[j].name;
+      vars["name"] = std::string(value_index[j].name);
       printer->Print (vars, "  { \"$name$\", $index$ },\n");
     }
     printer->Print(vars, "};\n");

--- a/protoc-gen-c/c_field.cc
+++ b/protoc-gen-c/c_field.cc
@@ -116,9 +116,9 @@ void FieldGenerator::GenerateDescriptorInitializerGeneric(google::protobuf::io::
   variables["classname"] = FullNameToC(FieldScope(descriptor_)->full_name(), FieldScope(descriptor_)->file());
   variables["name"] = FieldName(descriptor_);
   if (opt.use_oneof_field_name())
-    variables["proto_name"] = oneof->name();
+    variables["proto_name"] = std::string(oneof->name());
   else
-    variables["proto_name"] = descriptor_->name();
+    variables["proto_name"] = std::string(descriptor_->name());
   variables["descriptor_addr"] = descriptor_addr;
   variables["value"] = SimpleItoa(descriptor_->number());
   if (oneof != NULL)

--- a/protoc-gen-c/c_helpers.cc
+++ b/protoc-gen-c/c_helpers.cc
@@ -342,7 +342,7 @@ unsigned
 WriteIntRanges(google::protobuf::io::Printer* printer, int n_values, const int *values, compat::StringView name)
 {
   std::map<std::string, std::string> vars;
-  vars["name"] = name;
+  vars["name"] = std::string(name);
   if (n_values > 0) {
     int n_ranges = 1;
     for (int i = 1; i < n_values; i++) {

--- a/protoc-gen-c/c_message.cc
+++ b/protoc-gen-c/c_message.cc
@@ -215,11 +215,11 @@ GenerateStructDefinition(google::protobuf::io::Printer* printer) {
     printer->Print("union {\n");
     printer->Indent();
 
-    std::vector<std::tuple<int, std::string_view, const google::protobuf::FieldDescriptor*>> sorted_fds;
+    std::vector<std::tuple<int, std::string, const google::protobuf::FieldDescriptor*>> sorted_fds;
 
     for (int j = 0; j < oneof->field_count(); j++) {
       const google::protobuf::FieldDescriptor* field = oneof->field(j);
-      std::string_view name = field->name();
+      auto name = std::string(field->name());
       int order = MessageGenerator::GetOneofUnionOrder(field);
       sorted_fds.push_back({order, name, field});
     }
@@ -462,12 +462,12 @@ GenerateHelperFunctionDefinitions(google::protobuf::io::Printer* printer,
 void MessageGenerator::
 GenerateMessageDescriptor(google::protobuf::io::Printer* printer, bool gen_init) {
   std::map<std::string, std::string> vars;
-  vars["fullname"] = descriptor_->full_name();
+  vars["fullname"] = std::string(descriptor_->full_name());
   vars["classname"] = FullNameToC(descriptor_->full_name(), descriptor_->file());
   vars["lcclassname"] = FullNameToLower(descriptor_->full_name(), descriptor_->file());
   vars["shortname"] = ToCamel(descriptor_->name());
   vars["n_fields"] = SimpleItoa(descriptor_->field_count());
-  vars["packagename"] = descriptor_->file()->package();
+  vars["packagename"] = std::string(descriptor_->file()->package());
 
   bool optimize_code_size = descriptor_->file()->options().has_optimize_for() &&
     descriptor_->file()->options().optimize_for() ==
@@ -499,7 +499,7 @@ GenerateMessageDescriptor(google::protobuf::io::Printer* printer, bool gen_init)
     const ProtobufCFieldOptions opt = fd->options().GetExtension(pb_c_field);
     if (fd->has_default_value()) {
       bool already_defined = false;
-      vars["name"] = fd->name();
+      vars["name"] = std::string(fd->name());
       vars["lcname"] = CamelToLower(fd->name());
       vars["maybe_static"] = "static ";
       vars["field_dv_ctype_suffix"] = "";
@@ -590,7 +590,7 @@ GenerateMessageDescriptor(google::protobuf::io::Printer* printer, bool gen_init)
       printer->Print(vars, "static const unsigned $lcclassname$__field_indices_by_name[] = {\n");
       for (int i = 0; i < descriptor_->field_count(); i++) {
         vars["index"] = SimpleItoa(field_indices[i].index);
-        vars["name"] = field_indices[i].name;
+        vars["name"] = std::string(field_indices[i].name);
         printer->Print(vars, "  $index$,   /* field[$index$] = $name$ */\n");
       }
       printer->Print("};\n");

--- a/protoc-gen-c/c_service.cc
+++ b/protoc-gen-c/c_service.cc
@@ -72,13 +72,13 @@ namespace protobuf_c {
 ServiceGenerator::ServiceGenerator(const google::protobuf::ServiceDescriptor* descriptor,
                                    const std::string& dllexport_decl)
   : descriptor_(descriptor) {
-  vars_["name"] = descriptor_->name();
-  vars_["fullname"] = descriptor_->full_name();
+  vars_["name"] = std::string(descriptor_->name());
+  vars_["fullname"] = std::string(descriptor_->full_name());
   vars_["cname"] = FullNameToC(descriptor_->full_name(), descriptor_->file());
   vars_["lcfullname"] = FullNameToLower(descriptor_->full_name(), descriptor_->file());
   vars_["ucfullname"] = FullNameToUpper(descriptor_->full_name(), descriptor_->file());
   vars_["lcfullpadd"] = ConvertToSpaces(vars_["lcfullname"]);
-  vars_["package"] = descriptor_->file()->package();
+  vars_["package"] = std::string(descriptor_->file()->package());
   if (dllexport_decl.empty()) {
     vars_["dllexport"] = "";
   } else {
@@ -207,7 +207,7 @@ void ServiceGenerator::GenerateServiceDescriptor(google::protobuf::io::Printer* 
                        "{\n");
   for (unsigned i = 0; i < n_methods; i++) {
     const google::protobuf::MethodDescriptor* method = descriptor_->method(i);
-    vars_["method"] = method->name();
+    vars_["method"] = std::string(method->name());
     vars_["input_descriptor"] = "&" + FullNameToLower(method->input_type()->full_name(), method->input_type()->file()) + "__descriptor";
     vars_["output_descriptor"] = "&" + FullNameToLower(method->output_type()->full_name(), method->output_type()->file()) + "__descriptor";
     if (optimize_code_size) {
@@ -229,12 +229,12 @@ void ServiceGenerator::GenerateServiceDescriptor(google::protobuf::io::Printer* 
     printer->Print(vars_, "const unsigned $lcfullname$__method_indices_by_name[] = {\n");
     for (int i = 0; i < n_methods; i++) {
       vars_["i"] = SimpleItoa(mi_array[i].i);
-      vars_["name"] = mi_array[i].name;
+      vars_["name"] = std::string(mi_array[i].name);
       vars_["comma"] = (i + 1 < n_methods) ? "," : " ";
       printer->Print(vars_, "  $i$$comma$        /* $name$ */\n");
     }
     printer->Print(vars_, "};\n");
-    vars_["name"] = descriptor_->name();
+    vars_["name"] = std::string(descriptor_->name());
   }
 
   if (optimize_code_size) {


### PR DESCRIPTION
protobuf 30.x changes various APIs to return `string_view`'s rather than `string&`'s. This broke protobuf-c, since we were relying on the implicit construction of strings from `string&`'s in various places.

This commit explicitly constructs strings from the `string_view`'s returned by the protobuf 30.x API when we need to store an owned string (e.g. in a hash map). This maintains compatibility with older versions of protobuf such as 3.21 in Debian/Ubuntu while extending compatibility to the latest protobuf 30.x.

Without this commit we get lots of errors like this when compiling against protobuf 30.x:

    protoc-gen-c/c_field.cc:119:43: error: no match for 'operator=' (operand types are 'std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >::mapped_type' {aka 'std::__cxx11::basic_string<char>'} and 'google::protobuf::internal::DescriptorStringView' {aka 'absl::debian7::string_view'})