### PR TITLE
Fix Wasm build without protoc

### DIFF
--- a/build-cmake/CMakeLists.txt
+++ b/build-cmake/CMakeLists.txt
@@ -37,7 +37,6 @@ endif()
 
 
 find_package(absl CONFIG)
-find_package(GTest CONFIG)
 
 # for static protobuf libraries include the dependencies
 if(Protobuf_USE_STATIC_LIBS)

--- a/build-cmake/CMakeLists.txt
+++ b/build-cmake/CMakeLists.txt
@@ -35,7 +35,6 @@ if(BUILD_PROTOC)
   endif()
 endif()
 
-
 find_package(absl CONFIG)
 
 # for static protobuf libraries include the dependencies

--- a/build-cmake/CMakeLists.txt
+++ b/build-cmake/CMakeLists.txt
@@ -11,21 +11,33 @@ cmake_policy(SET CMP0112 NEW)
 
 project(protobuf-c C CXX)
 
+# options
+option(BUILD_PROTOC "Build protoc-gen-c" ON)
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+  option(BUILD_TESTS "Build tests" ON)
+else()
+  option(BUILD_TESTS "Build tests" OFF)
+endif()
+
 if(MSVC AND NOT BUILD_SHARED_LIBS)
   set(Protobuf_USE_STATIC_LIBS ON)
 endif()
 
-find_package(Protobuf CONFIG)
-if(Protobuf_FOUND)
-  # Keep compatibility with FindProtobuf CMake module
-  set(PROTOBUF_PROTOC_EXECUTABLE $<TARGET_FILE:protobuf::protoc>)
-  get_target_property(PROTOBUF_INCLUDE_DIR protobuf::libprotobuf INTERFACE_INCLUDE_DIRECTORIES)
-else()
-  message(STATUS "Protobuf CMake config not found fallback to Cmake Module")
-  find_package(Protobuf REQUIRED)
+if(BUILD_PROTOC)
+  find_package(Protobuf CONFIG)
+  if(Protobuf_FOUND)
+    # Keep compatibility with FindProtobuf CMake module
+    set(PROTOBUF_PROTOC_EXECUTABLE $<TARGET_FILE:protobuf::protoc>)
+    get_target_property(PROTOBUF_INCLUDE_DIR protobuf::libprotobuf INTERFACE_INCLUDE_DIRECTORIES)
+  else()
+    message(STATUS "Protobuf CMake config not found fallback to Cmake Module")
+    find_package(Protobuf REQUIRED)
+  endif()
 endif()
 
+
 find_package(absl CONFIG)
+find_package(GTest CONFIG)
 
 # for static protobuf libraries include the dependencies
 if(Protobuf_USE_STATIC_LIBS)
@@ -42,14 +54,6 @@ if(Protobuf_USE_STATIC_LIBS)
       $<TARGET_NAME_IF_EXISTS:utf8_range::utf8_range>)
 elseif(WIN32)
   set(protobuf_ABSL_USED_TARGETS $<TARGET_NAME_IF_EXISTS:absl::abseil_dll>)
-endif()
-
-# options
-option(BUILD_PROTOC "Build protoc-gen-c" ON)
-if(CMAKE_BUILD_TYPE MATCHES Debug)
-  option(BUILD_TESTS "Build tests" ON)
-else()
-  option(BUILD_TESTS "Build tests" OFF)
 endif()
 
 include(TestBigEndian)


### PR DESCRIPTION
When compiling protobuf-c to WebAssembly, you must build without protoc because WebAssembly does not provide threads yet. This commit makes that optional, which is already the case when building with autotools.