### PR TITLE
Captures json_name field option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -358,7 +358,7 @@ t_json_name_json_name_SOURCES = \
 t_json_name_json_name_LDADD = \
 	protobuf-c/libprotobuf-c.la
 t/json_name/json_name.pb-c.c t/json_name/json_name.pb-c.h: $(top_builddir)/protoc-gen-c/protoc-gen-c$(EXEEXT) $(top_srcdir)/t/json_name/json_name.proto
-	$(AM_V_GEN)@PROTOC@ --plugin=protoc-gen-c=$(top_builddir)/protoc-gen-c/protoc-gen-c$(EXEEXT) -I$(top_srcdir) --c_out=$(top_builddir) $(top_srcdir)/t/json_name/json_name.proto
+	$(AM_V_GEN)@PROTOC@ --plugin=protoc-gen-c=$(top_builddir)/protoc-gen-c/protoc-gen-c$(EXEEXT) -I$(top_srcdir) --c_out=json_name=true:$(top_builddir) $(top_srcdir)/t/json_name/json_name.proto
 BUILT_SOURCES += \
 	t/json_name/json_name.pb-c.c t/json_name/json_name.pb-c.h
 EXTRA_DIST += \

--- a/Makefile.am
+++ b/Makefile.am
@@ -347,6 +347,23 @@ BUILT_SOURCES += \
 EXTRA_DIST += \
 	t/issue745/issue745.proto
 
+# JSON name test
+check_PROGRAMS += \
+	t/json_name/json_name
+TESTS += \
+	t/json_name/json_name
+t_json_name_json_name_SOURCES = \
+	t/json_name/json_name.c \
+	t/json_name/json_name.pb-c.c
+t_json_name_json_name_LDADD = \
+	protobuf-c/libprotobuf-c.la
+t/json_name/json_name.pb-c.c t/json_name/json_name.pb-c.h: $(top_builddir)/protoc-gen-c/protoc-gen-c$(EXEEXT) $(top_srcdir)/t/json_name/json_name.proto
+	$(AM_V_GEN)@PROTOC@ --plugin=protoc-gen-c=$(top_builddir)/protoc-gen-c/protoc-gen-c$(EXEEXT) -I$(top_srcdir) --c_out=$(top_builddir) $(top_srcdir)/t/json_name/json_name.proto
+BUILT_SOURCES += \
+	t/json_name/json_name.pb-c.c t/json_name/json_name.pb-c.h
+EXTRA_DIST += \
+	t/json_name/json_name.proto
+
 endif # CROSS_COMPILING
 
 endif # BUILD_COMPILER

--- a/protobuf-c/protobuf-c.h
+++ b/protobuf-c/protobuf-c.h
@@ -610,13 +610,12 @@ struct ProtobufCFieldDescriptor {
 	 */
 	uint32_t		flags;
 
-	/** The JSON name for this field, if specified by json_name option. May be NULL. */
-	const char		*json_name;
-
 	/** Reserved for future use. */
 	unsigned		reserved_flags;
-	/** Reserved for future use. */
-	void			*reserved2;
+
+	/** The JSON name for this field, if specified by json_name option. May be NULL. */
+	const char		*json_name;
+	
 	/** Reserved for future use. */
 	void			*reserved3;
 };

--- a/protobuf-c/protobuf-c.h
+++ b/protobuf-c/protobuf-c.h
@@ -610,6 +610,9 @@ struct ProtobufCFieldDescriptor {
 	 */
 	uint32_t		flags;
 
+	/** The JSON name for this field, if specified by json_name option. May be NULL. */
+	const char		*json_name;
+
 	/** Reserved for future use. */
 	unsigned		reserved_flags;
 	/** Reserved for future use. */

--- a/protobuf-c/protobuf-c.proto
+++ b/protobuf-c/protobuf-c.proto
@@ -79,6 +79,9 @@ extend google.protobuf.MessageOptions {
 message ProtobufCFieldOptions {
     // Treat string as bytes in generated code
     optional bool string_as_bytes = 1 [default = false];
+    
+    // Custom name in JSON serialization
+    optional string json_name = 2;
 }
 
 extend google.protobuf.FieldOptions {

--- a/protoc-gen-c/c_field.cc
+++ b/protoc-gen-c/c_field.cc
@@ -200,6 +200,14 @@ void FieldGenerator::GenerateDescriptorInitializerGeneric(google::protobuf::io::
   printer->Print(variables, "  $descriptor_addr$,\n");
   printer->Print(variables, "  $default_value$,\n");
   printer->Print(variables, "  $flags$,             /* flags */\n");
+  
+  if (descriptor_->has_json_name()) {
+    std::string json_name = descriptor_->json_name();
+    printer->Print("  \"$json_name$\",  /* json_name */\n", "json_name", json_name);
+  } else {
+    printer->Print("  NULL,  /* json_name */\n");
+  }
+  
   printer->Print(variables, "  0,NULL,NULL    /* reserved1,reserved2, etc */\n");
   printer->Print("},\n");
 }

--- a/protoc-gen-c/c_field.cc
+++ b/protoc-gen-c/c_field.cc
@@ -200,6 +200,8 @@ void FieldGenerator::GenerateDescriptorInitializerGeneric(google::protobuf::io::
   printer->Print(variables, "  $descriptor_addr$,\n");
   printer->Print(variables, "  $default_value$,\n");
   printer->Print(variables, "  $flags$,             /* flags */\n");
+
+  printer->Print(variables, "  0,   /* reserved flags */\n");
   
   if (json_name_ && descriptor_->has_json_name()) {
     std::string json_name = descriptor_->json_name();
@@ -208,7 +210,7 @@ void FieldGenerator::GenerateDescriptorInitializerGeneric(google::protobuf::io::
     printer->Print("  NULL,  /* json_name */\n");
   }
   
-  printer->Print(variables, "  0,NULL,NULL    /* reserved1,reserved2, etc */\n");
+  printer->Print(variables, "  NULL    /* reserved3 */\n");
   printer->Print("},\n");
 }
 

--- a/protoc-gen-c/c_field.h
+++ b/protoc-gen-c/c_field.h
@@ -74,7 +74,8 @@ namespace protobuf_c {
 
 class FieldGenerator {
  public:
-  explicit FieldGenerator(const google::protobuf::FieldDescriptor *descriptor) : descriptor_(descriptor) {}
+  explicit FieldGenerator(const google::protobuf::FieldDescriptor *descriptor, bool json_name = false) 
+    : descriptor_(descriptor), json_name_(json_name) {}
   virtual ~FieldGenerator();
 
   // Generate definitions to be included in the structure.
@@ -97,21 +98,26 @@ class FieldGenerator {
                                             const std::string &type_macro,
                                             const std::string &descriptor_addr) const;
   const google::protobuf::FieldDescriptor *descriptor_;
+  bool json_name_;
+  
+  // Allow FieldGeneratorMap to access json_name_
+  friend class FieldGeneratorMap;
 };
 
 // Convenience class which constructs FieldGenerators for a Descriptor.
 class FieldGeneratorMap {
  public:
-  explicit FieldGeneratorMap(const google::protobuf::Descriptor* descriptor);
+  explicit FieldGeneratorMap(const google::protobuf::Descriptor* descriptor, bool json_name = false);
   ~FieldGeneratorMap();
 
   const FieldGenerator& get(const google::protobuf::FieldDescriptor* field) const;
 
  private:
   const google::protobuf::Descriptor* descriptor_;
+  bool json_name_;
   std::unique_ptr<std::unique_ptr<FieldGenerator>[]> field_generators_;
 
-  static FieldGenerator* MakeGenerator(const google::protobuf::FieldDescriptor* field);
+  FieldGenerator* MakeGenerator(const google::protobuf::FieldDescriptor* field);
 };
 
 }  // namespace protobuf_c

--- a/protoc-gen-c/c_file.cc
+++ b/protoc-gen-c/c_file.cc
@@ -79,7 +79,8 @@ namespace protobuf_c {
 // ===================================================================
 
 FileGenerator::FileGenerator(const google::protobuf::FileDescriptor* file,
-                             const std::string& dllexport_decl)
+                             const std::string& dllexport_decl,
+                             bool json_name)
   : file_(file),
     message_generators_(
       new std::unique_ptr<MessageGenerator>[file->message_type_count()]),
@@ -92,7 +93,7 @@ FileGenerator::FileGenerator(const google::protobuf::FileDescriptor* file,
 
   for (int i = 0; i < file->message_type_count(); i++) {
     message_generators_[i].reset(
-      new MessageGenerator(file->message_type(i), dllexport_decl));
+      new MessageGenerator(file->message_type(i), dllexport_decl, json_name));
   }
 
   for (int i = 0; i < file->enum_type_count(); i++) {

--- a/protoc-gen-c/c_file.h
+++ b/protoc-gen-c/c_file.h
@@ -84,7 +84,8 @@ class FileGenerator {
  public:
   // See generator.cc for the meaning of dllexport_decl.
   explicit FileGenerator(const google::protobuf::FileDescriptor* file,
-                         const std::string& dllexport_decl);
+                         const std::string& dllexport_decl,
+                         bool json_name = false);
   ~FileGenerator();
 
   void GenerateHeader(google::protobuf::io::Printer* printer);

--- a/protoc-gen-c/c_generator.cc
+++ b/protoc-gen-c/c_generator.cc
@@ -131,10 +131,13 @@ bool CGenerator::Generate(const google::protobuf::FileDescriptor* file,
   // FOO_EXPORT is a macro which should expand to __declspec(dllexport) or
   // __declspec(dllimport) depending on what is being compiled.
   std::string dllexport_decl;
+  bool json_name = false; // Default to false for backward compatibility
 
   for (unsigned i = 0; i < options.size(); i++) {
     if (options[i].first == "dllexport_decl") {
       dllexport_decl = options[i].second;
+    } else if (options[i].first == "json_name") {
+      json_name = options[i].second == "true" || options[i].second == "1";
     } else {
       *error = "Unknown generator option: " + options[i].first;
       return false;
@@ -147,7 +150,7 @@ bool CGenerator::Generate(const google::protobuf::FileDescriptor* file,
   std::string basename = StripProto(file->name());
   basename.append(".pb-c");
 
-  FileGenerator file_generator(file, dllexport_decl);
+  FileGenerator file_generator(file, dllexport_decl, json_name);
 
   // Generate header.
   {

--- a/protoc-gen-c/c_message.cc
+++ b/protoc-gen-c/c_message.cc
@@ -83,10 +83,12 @@
 namespace protobuf_c {
 
 MessageGenerator::MessageGenerator(const google::protobuf::Descriptor* descriptor,
-                                   const std::string& dllexport_decl)
+                                   const std::string& dllexport_decl,
+                                   bool json_name)
   : descriptor_(descriptor),
     dllexport_decl_(dllexport_decl),
-    field_generators_(descriptor),
+    json_name_(json_name),
+    field_generators_(descriptor, json_name),
     nested_generators_(new std::unique_ptr<MessageGenerator>[
       descriptor->nested_type_count()]),
     enum_generators_(new std::unique_ptr<EnumGenerator>[
@@ -96,7 +98,7 @@ MessageGenerator::MessageGenerator(const google::protobuf::Descriptor* descripto
 
   for (int i = 0; i < descriptor->nested_type_count(); i++) {
     nested_generators_[i].reset(
-      new MessageGenerator(descriptor->nested_type(i), dllexport_decl));
+      new MessageGenerator(descriptor->nested_type(i), dllexport_decl, json_name));
   }
 
   for (int i = 0; i < descriptor->enum_type_count(); i++) {

--- a/protoc-gen-c/c_message.h
+++ b/protoc-gen-c/c_message.h
@@ -80,7 +80,8 @@ class MessageGenerator {
  public:
   // See generator.cc for the meaning of dllexport_decl.
   explicit MessageGenerator(const google::protobuf::Descriptor* descriptor,
-                            const std::string& dllexport_decl);
+                            const std::string& dllexport_decl,
+                            bool json_name = false);
   ~MessageGenerator();
 
   // Header stuff.
@@ -126,6 +127,7 @@ class MessageGenerator {
 
   const google::protobuf::Descriptor* descriptor_;
   std::string dllexport_decl_;
+  bool json_name_;
   FieldGeneratorMap field_generators_;
   std::unique_ptr<std::unique_ptr<MessageGenerator>[]> nested_generators_;
   std::unique_ptr<std::unique_ptr<EnumGenerator>[]> enum_generators_;

--- a/t/json_name/.gitignore
+++ b/t/json_name/.gitignore
@@ -1,0 +1,1 @@
+json_name

--- a/t/json_name/json_name.c
+++ b/t/json_name/json_name.c
@@ -1,0 +1,76 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "t/json_name/json_name.pb-c.h"
+
+int main(void)
+{
+    JsonNames msg = JSON_NAMES__INIT;
+    const ProtobufCFieldDescriptor *field;
+
+    // Test regular field json_name
+    field = protobuf_c_message_descriptor_get_field_by_name(
+        &json_names__descriptor,
+        "regular_field_a"
+    );
+    assert(field != NULL);
+    assert(strcmp(field->json_name, "customNameA") == 0);
+
+    // Test snake_case field json_name
+    field = protobuf_c_message_descriptor_get_field_by_name(
+        &json_names__descriptor,
+        "regular_field_b"
+    );
+    assert(field != NULL);
+    assert(strcmp(field->json_name, "customNameB") == 0);
+
+    // Test no json_name field falls back to camelCase
+    field = protobuf_c_message_descriptor_get_field_by_name(
+        &json_names__descriptor,
+        "no_json_name"
+    );
+    assert(field != NULL);
+    assert(strcmp(field->json_name, "noJsonName") == 0);
+
+    // Test oneof field json_names
+    field = protobuf_c_message_descriptor_get_field_by_name(
+        &json_names__descriptor,
+        "oneof_field_a"
+    );
+    assert(field != NULL);
+    assert(strcmp(field->json_name, "oneofCustomA") == 0);
+
+    field = protobuf_c_message_descriptor_get_field_by_name(
+        &json_names__descriptor,
+        "oneof_field_b"
+    );
+    assert(field != NULL);
+    assert(strcmp(field->json_name, "oneofCustomB") == 0);
+
+    // Test map field json_name
+    field = protobuf_c_message_descriptor_get_field_by_name(
+        &json_names__descriptor,
+        "map_field"
+    );
+    assert(field != NULL);
+    assert(strcmp(field->json_name, "customMap") == 0);
+
+    // Test repeated field json_name
+    field = protobuf_c_message_descriptor_get_field_by_name(
+        &json_names__descriptor,
+        "numbers"
+    );
+    assert(field != NULL);
+    assert(strcmp(field->json_name, "numberArray") == 0);
+
+    // Test nested message field json_name
+    field = protobuf_c_message_descriptor_get_field_by_name(
+        &json_names__descriptor,
+        "nested_message"
+    );
+    assert(field != NULL);
+    assert(strcmp(field->json_name, "nestedMsg") == 0);
+
+    return EXIT_SUCCESS;
+}

--- a/t/json_name/json_name.proto
+++ b/t/json_name/json_name.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+message JsonNames {
+	string regular_field_a = 1 [json_name = "customNameA"];
+	int32 regular_field_b = 2 [json_name = "customNameB"];
+
+	string no_json_name = 3;
+
+	oneof test_oneof {
+		bool oneof_field_a = 10 [json_name = "oneofCustomA"];
+		string oneof_field_b = 11 [json_name = "oneofCustomB"];
+		int64 oneof_field_c = 12 [json_name = "oneofCustomC"];
+	}
+
+	map<string, string> map_field = 20 [json_name = "customMap"];
+	repeated double numbers = 21 [json_name = "numberArray"];
+
+	string default_string = 30;
+	bytes bytes_field = 31 [json_name = "bytesCustom"];
+
+	message Nested {
+		string nested_field = 1 [json_name = "nestedCustom"];
+	}
+	Nested nested_message = 40 [json_name = "nestedMsg"];
+}


### PR DESCRIPTION
Currently the `json_name` field option is not captured in the generated C code:

```proto
syntax = "proto3";

message MyMessage {
  string my_field = 1 [json_name = "myCustomFieldName"]; // myCustomFieldName not captured
}
```

Capturing `json_name` can be useful for some downstream use cases. In my case, I'm building a modified version of [protobuf2json-c](https://github.com/Sannis/protobuf2json-c) that works with proto3, but needs access to the `json_name` field option if it was defined.

## Implementation
Since this can be a breaking change, I implemented this as an opt-in generator option:

```shell
protoc --c_out=json_name=true:/path/to/output your_proto_file.proto
```

This PR currently replaces the `reserved2` field descriptor value with a `json_name` char pointer. If the `json_name` generator option was not set, this will be set to NULL as before. If it was set, it will use the `descriptor_->json_name()` provided by the protobuf lib.

If there is a another way to capture this instead of using the reserved field, please let me know.

## Tests
I've added a test to `./t/json_name` that confirms that `json_name` is populated correctly.

Thanks for considering, let me know if you have any questions 🙂